### PR TITLE
feat(docs): strengthen SEO and GEO metadata

### DIFF
--- a/packages/docs/.vitepress/common/index.ts
+++ b/packages/docs/.vitepress/common/index.ts
@@ -35,13 +35,24 @@ export const PREVIEW_CODE = `
 `;
 
 export const DESCRIPTION =
-  'Based on web component library, common function library utils, personal article record and so on';
+  'ran is an open-source front-end ecosystem by chaxus: ranui, a native Web Components UI library, and ranuts, a tree-shakeable TypeScript utility library, plus low-level web-infrastructure experiments.';
 
 export const HOME = 'https://ran.chaxus.com/';
 
 export const BASE_PATH = '/';
 
 export const HOME_ICON = `${HOME}home.svg`;
+
+// og:image must be a raster image (PNG/JPG) — social crawlers (X/Twitter, Facebook,
+// LinkedIn, Slack, Discord) do not render SVG previews. This 2560×1440 screenshot
+// doubles as the summary_large_image card.
+export const OG_IMAGE = `${HOME}screenshots_2560x1440.jpg`;
+
+export const OG_IMAGE_WIDTH = '2560';
+
+export const OG_IMAGE_HEIGHT = '1440';
+
+export const OG_IMAGE_ALT = 'ran — Web Components UI library (ranui) and utility library (ranuts)';
 
 export const UTILS_PATH = `${HOME}src/ranuts/utils/`;
 

--- a/packages/docs/.vitepress/config.ts
+++ b/packages/docs/.vitepress/config.ts
@@ -9,8 +9,11 @@ import {
   GOOGLE_ANALYSE,
   GTAG,
   HOME,
-  HOME_ICON,
   // KEY_WORDS,
+  OG_IMAGE,
+  OG_IMAGE_ALT,
+  OG_IMAGE_HEIGHT,
+  OG_IMAGE_WIDTH,
   PREVIEW_CODE,
   RANUI_PATH,
   SERVICE_WORK,
@@ -97,8 +100,17 @@ export default defineConfig({
     const enUrl = ORIGIN + relToUrl(enRel);
     const cnUrl = ORIGIN + relToUrl(cnRel);
 
+    // The home page's document <title> is otherwise just "ran" (title === site
+    // title, so no template is applied). Promote it to the full tagline so the
+    // most important on-page SEO signal carries the product keywords.
+    const isHome = enRel === 'index.md';
+    if (isHome) {
+      pageData.title = SITE_TAGLINE;
+      pageData.titleTemplate = false;
+    }
+
     const title = pageData.title || 'ran';
-    const ogTitle = title === 'ran' ? SITE_TAGLINE : `${title} | ran`;
+    const ogTitle = isHome ? SITE_TAGLINE : `${title} | ran`;
     const desc =
       pageData.frontmatter.description ||
       pageData.description ||
@@ -183,7 +195,7 @@ export default defineConfig({
     ['link', { rel: 'manifest', href: `${BASE_PATH}manifest.json` }],
     ['meta', { name: 'theme-color', content: '#646cff' }],
     // author
-    ['meta', { name: 'author', content: '81380@163.com' }],
+    ['meta', { name: 'author', content: 'chaxus' }],
     // 表示爬虫对此页面的处理行为 或 应当遵守的规则，是用来做搜索引擎抓取的
     // all：搜索引擎将索引此网页，并继续通过此 网页的链接索引文件 将被检索
     // none：搜索引擎将 忽略 此网页
@@ -195,9 +207,18 @@ export default defineConfig({
     // 已经有国际化，禁止谷歌自动翻译
     ['meta', { name: 'google', content: 'notranslate' }],
     // og — per-page og:title / og:description / og:url are injected in transformPageData.
-    // Only the shared image + type stay static here.
-    ['meta', { property: 'og:image', content: HOME_ICON }],
+    // Only the shared image + type + site identity stay static here.
+    ['meta', { property: 'og:image', content: OG_IMAGE }],
+    ['meta', { property: 'og:image:width', content: OG_IMAGE_WIDTH }],
+    ['meta', { property: 'og:image:height', content: OG_IMAGE_HEIGHT }],
+    ['meta', { property: 'og:image:alt', content: OG_IMAGE_ALT }],
     ['meta', { property: 'og:type', content: 'website' }],
+    ['meta', { property: 'og:site_name', content: 'ran' }],
+    ['meta', { property: 'og:locale', content: 'en_US' }],
+    ['meta', { property: 'og:locale:alternate', content: 'zh_CN' }],
+    // twitter:image is explicit so the large-summary card never falls back to the icon.
+    ['meta', { name: 'twitter:image', content: OG_IMAGE }],
+    ['meta', { name: 'twitter:image:alt', content: OG_IMAGE_ALT }],
     // site-wide structured data (JSON-LD): the site + its author (personal brand)
     ['script', { type: 'application/ld+json' }, JSON.stringify(SITE_JSONLD)],
     [

--- a/packages/docs/public/manifest.json
+++ b/packages/docs/public/manifest.json
@@ -1,11 +1,11 @@
 {
-    "name": "ran", 
+    "name": "ran — ranui Web Components & ranuts utilities",
     "short_name": "ran",
     "id":"/",
     "start_url": "/",
-    "display": "standalone", 
+    "display": "standalone",
     "background_color": "#fff",
-    "description": "A Troupe of little vagrants of the world, leave your footprints in my words .",
+    "description": "Documentation for ran: ranui, a native Web Components UI library, and ranuts, a tree-shakeable TypeScript utility library.",
     "icons": [
       {
         "src": "/icon_48.png",
@@ -44,14 +44,14 @@
         "sizes": "2560x1440",
         "type": "image/jpg",
         "form_factor": "wide",
-        "label": "Home screen of Awesome App"
+        "label": "ran documentation home"
       },
       {
         "src": "/screenshots_748x1340.jpg",
         "sizes": "748x1340",
         "type": "image/jpg",
         "form_factor": "narrow",
-        "label": "List of Awesome Resources available in Awesome App"
+        "label": "ran component and utility docs"
       }
     ]
   }


### PR DESCRIPTION
## Summary

The docs site already has a mature SEO/GEO foundation (sitemap, canonical, hreflang alternates, per-page OG/Twitter, WebSite + Person + SoftwareSourceCode JSON-LD, `robots.txt` with AI-bot tiering, `llms.txt` + build-time `llms-full.txt`). This PR closes the remaining gaps.

## Changes

- **Home `<title>`** now carries the full product tagline (`ran — Web Components UI library (ranui) & utility library (ranuts)`) instead of the bare word `ran`. The tagline already existed but was only used for `og:title`; the actual `<title>` — the single most important on-page signal — had no keywords. Non-home pages keep their `Page | ran` template.
- **`og:image`** switches from an SVG icon to the existing 2560×1440 raster screenshot. X/Twitter, Facebook, LinkedIn, Slack and Discord do **not** render SVG previews, so shares were showing blank. Adds `og:image:width/height/alt` and an explicit `twitter:image` so the `summary_large_image` card never falls back to the icon.
- **Site description** rewritten into a grammatical, keyword-rich sentence (feeds both the meta description and the WebSite JSON-LD). The previous copy — "Based on web component library, common function library utils, personal article record and so on" — was ungrammatical.
- **`og:site_name` + `og:locale` / `og:locale:alternate`** added to complement the existing hreflang alternates.
- **`author` meta** changed from a raw email to `chaxus`, matching the Person JSON-LD and personal brand.
- **`manifest.json`** name/description/screenshot labels replaced (was a Tagore quote + "Awesome App" placeholders).

## Verification

- `tsc --noEmit`: no errors.
- `vitepress build`: succeeds; inspected rendered `dist` output.
  - Home (EN + CN) `<title>` = full tagline.
  - `og:image` = `.../screenshots_2560x1440.jpg` with width/height/alt.
  - `og:site_name`, `og:locale`, `twitter:image`, `author=chaxus` all present.
  - Sub-pages (e.g. `ranui`) still render `ranui | ran`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)