### PR TITLE
feat(ranuts): binary payload utils (base64/gzip/sniffing/decoding/save)

### DIFF
--- a/packages/docs/cn/src/ranuts/api.md
+++ b/packages/docs/cn/src/ranuts/api.md
@@ -1,6 +1,6 @@
 ---
 title: ranuts API 参考
-description: ranuts 导出的全部符号 — 6 个入口点，共 393 个导出，含签名与描述。
+description: ranuts 导出的全部符号 — 6 个入口点，共 402 个导出，含签名与描述。
 ---
 
 # ranuts API（自动生成）
@@ -12,11 +12,11 @@ description: ranuts 导出的全部符号 — 6 个入口点，共 393 个导出
 请从符号所属的**子路径**导入，例如 `import { debounce } from
 'ranuts/utils'`。根入口 `ranuts` 重新导出 utils + visual 的全部符号。
 
-**393 个导出**，共 6 个入口点。生成时间 2026-08-13T14:02:17.188Z。
+**402 个导出**，共 6 个入口点。生成时间 2026-08-17T14:42:17.466Z。
 
 ## 入口点
 
-- [`ranuts/utils`](#ranuts-utils) — 浏览器与通用工具函数 · _浏览器 + node_ · 307 个导出
+- [`ranuts/utils`](#ranuts-utils) — 浏览器与通用工具函数 · _浏览器 + node_ · 316 个导出
 - [`ranuts/sw`](#ranuts-sw) — Service Worker 缓存策略与预缓存协议 · _仅 service worker_ · 9 个导出
 - [`ranuts/node`](#ranuts-node) — Node 服务端工具（fs / http / ws / 中间件） · _仅 node_ · 26 个导出
 - [`ranuts/visual`](#ranuts-visual) — 2D 渲染引擎（Canvas / WebGL / WebGPU） · _仅浏览器_ · 16 个导出
@@ -41,11 +41,13 @@ import { /* … */ } from 'ranuts/utils';
 - `appendUrl(url: string, params?: Record<string, string>) => string` — Turn an object into a query string and append it to a URL
 - `arrayBufferToString(buffer: ArrayBuffer | Uint8Array) => string` — Decode bytes into a string using the sniffed encoding. Required when reading
 - `autosizeTextarea(element: HTMLTextAreaElement) => (() => void)` — Make a `<textarea>` grow and shrink with its content, so a long message is
+- `base64ToBytes(base64: string) => Uint8Array<ArrayBuffer>` — Decode base64 into bytes. Accepts a bare payload or a full
 - `blendMultiply(base: RGB, blend: RGB) => RGB` — Multiply blend of two colours (channel-wise `base * blend`). Channels in 0..1.
 - `blendOverlay(base: RGB, blend: RGB) => RGB` — Overlay blend of two colours (multiply in shadows, screen in highlights). Channels in 0..1.
 - `blendScreen(base: RGB, blend: RGB) => RGB` — Screen blend of two colours (channel-wise `1 - (1 - base)(1 - blend)`). Channels in 0..1.
 - `brightnessContrast(color: RGB, brightness: number, contrast: number) => RGB` — Adjust brightness and contrast of a colour: `(c - 0.5) * contrast + 0.5 + brightness` per channel. Channels in 0..1.
 - `buildOffsets(lengths: readonly number[]) => number[]` — The global start offset of every chunk in the concatenated coordinate
+- `bytesToBase64(data: Uint8Array | ArrayBuffer) => string` — Encode bytes as base64 without blowing the call stack.
 - `checkEncoding(uint8Array: Uint8Array) => string`
 - `clamp(value: number, min: number, max: number) => number` — Clamp `value` into the inclusive range `[min, max]`.
 - `clearBr(str?: string) => string` — Strip whitespace, line breaks and HTML tags out of a string
@@ -75,6 +77,7 @@ import { /* … */ } from 'ranuts/utils';
 - `currentDevice() => CurrentDevice`
 - `cutRound(img: ImgSource, radius: number) => ImgSource` — Round an image's corners, returning an offscreen canvas.
 - `debounce<T extends (...args: any[]) => any>(fn: T, ms?: number) => Debounced<T>` — Debounce — on a burst of calls, run only the last one, **`ms` milliseconds
+- `decodeTextBytes(bytes: Uint8Array, encodings?: string[]) => string` — Decode text bytes, trying encodings in order until one holds.
 - `deferred<T = void>() => Deferred<T>` — A promise plus its `resolve` / `reject`, for the case where the thing that
 - `delay(ms: number) => Promise<void>` — Resolve after `ms` milliseconds. Uses the bare `setTimeout`, so it works in
 - `detectLanguage(text: string, sampleSize?: number) => TextLanguage` — Decide a text's primary language from the ratio of CJK to Latin characters.
@@ -82,6 +85,7 @@ import { /* … */ } from 'ranuts/utils';
 - `encodeUrl(url: string) => string` — Encode a URL to a percent-encoded form, excluding already-encoded sequences.
 - `escapeHtml(string?: string | number | null) => string`
 - `fanShapedByArc(ctx: CanvasRenderingContext2D, maxRadius: number, start: number, end: number, gutter: number) => void` — Trace a pie slice with arc(), including the gutter between slices.
+- `fetchMaybeGzip(input: RequestInfo | URL, init?: RequestInit) => Promise<Uint8Array>` — Fetch a resource that may be delivered gzipped or already
 - `filterObj(obj: Record<string, unknown>, list: Array<string>) => Record<string, unknown>` — Return a new object without the properties whose values appear in `list` — typically used to drop empty strings and nulls
 - `fit(value: number, a1: number, a2: number, b1: number, b2: number) => number` — Remap `value` from `[a1, a2]` onto `[b1, b2]` and clamp to the output range — the shader `fit`.
 - `formatDate(value?: DateInput, pattern?: string) => string` — Format a date with a token pattern. Accepts a timestamp, a date string, a
@@ -107,6 +111,7 @@ import { /* … */ } from 'ranuts/utils';
 - `getStatus(code?: number | string) => number | string | undefined` — Get the status code.
 - `getTangentByPointer(x: number, y: number) => Array<number>` — The tangent line at a point on a circle
 - `getWindow() => ClientRatio` — Get the viewport size across browsers
+- `gunzipMaybe(bytes: Uint8Array) => Promise<Uint8Array>` — Decompress bytes if — and only if — they are still gzipped.
 - `handleConsole(hooks?: (...args: unknown[]) => void) => (() => void)` — Tap into `console` so every call also reaches your hook, while still printing
 - `handleError(hooks?: (error: ErrorPayload) => void) => (() => void)` — Listen for uncaught errors and unhandled promise rejections, in the capture
 - `handleFetchHook(options?: Partial<Options>) => (() => void)` — Instrument `window.fetch` so every request, response and failure reaches your
@@ -128,6 +133,8 @@ import { /* … */ } from 'ranuts/utils';
 - `inflateRaw(data: Uint8Array) => Promise<Uint8Array>` — Decompress raw DEFLATE bytes (no zlib or gzip wrapper) — the form ZIP
 - `inverseLerp(a: number, b: number, value: number) => number` — Inverse of `lerp` — where `value` sits between `a` and `b`, as 0..1. Returns 0 when `a === b`. Not clamped.
 - `isEqual(value: any, other: any, seen?: Map<any, any>) => boolean` — Deep-compare two values.
+- `isGzip(bytes: Uint8Array) => boolean` — Whether the bytes start with the gzip magic number (1f 8b).
+- `isHtmlDocument(bytes: Uint8Array) => boolean` — Whether the bytes are an HTML document rather than the binary
 - `isImageSize(file: File, width?: number, height?: number) => Promise<boolean>` — Check an image's dimensions against a given width / height. When both are
 - `isInIframe() => boolean` — Whether this page is running inside an iframe. Returns false under SSR.
 - `isMobile() => boolean` — Whether this is a mobile device
@@ -136,6 +143,7 @@ import { /* … */ } from 'ranuts/utils';
 - `isString(obj: unknown) => boolean`
 - `isUrlCached(url: string) => Promise<boolean>` — Whether a URL is already in CacheStorage. When probing a group of files,
 - `isWeiXin() => boolean` — Whether this is the WeChat in-app browser
+- `isZipContainer(bytes: Uint8Array) => boolean` — Whether the bytes are a ZIP container (PK\x03\x04) — which is
 - `lerp(a: number, b: number, t: number) => number` — Linear interpolation from `a` to `b` by `t` (t=0 → a, t=1 → b). Not clamped.
 - `linearstep(edge0: number, edge1: number, x: number) => number` — Linear ramp — 0 below `edge0`, 1 above `edge1`, a straight line between (the shader `linearstep`, no smoothing).
 - `linearToSrgb(c: number) => number` — Convert one linear-light channel (0..1) to sRGB.
@@ -195,6 +203,7 @@ import { /* … */ } from 'ranuts/utils';
 - `rgbToHsv(r: number, g: number, b: number) => number[]` — Alias of `rgbToHsb` — HSV and HSB are two names for the same colour space.
 - `roundRectByArc(ctx: CanvasRenderingContext2D, ...[x, y, w, h, r]: number[]) => void` — Trace a rounded rectangle with arc(). A corner radius larger than half the
 - `saturation(color: RGB, amount: number) => RGB` — Adjust saturation by mixing toward the colour's luminance. `amount` 0 = greyscale, 1 = unchanged, >1 = more saturated. Channels in 0..1.
+- `saveFileToDisk(data: Blob | Uint8Array, fileName: string, options?: SaveFileOptions) => Promise<boolean>` — Save bytes to disk: a real "Save as" dialog through the File
 - `scriptOnLoad(urls: string[], append?: HTMLElement, callback?: () => void) => Promise<void>` — Insert script/link tags dynamically
 - `segmentByRanges<T>(text: string, chunkStart: number, ranges: readonly OffsetRange<T>[]) => Segment<T>[]` — Split one chunk of text into a sequence of plain / matched spans according
 - `serveWorker<Req extends WorkerRequestBase, Res extends object = object, Progress = unknown>(handler: (request: Req, context: WorkerHandlerContext<Progress>) =>…` — Serve requests inside a Web Worker, mirroring {@link WorkerClient} on the

--- a/packages/docs/src/ranuts/api.md
+++ b/packages/docs/src/ranuts/api.md
@@ -1,6 +1,6 @@
 ---
 title: ranuts API reference
-description: Every symbol exported by ranuts — 393 exports across 6 entry points, with signatures and descriptions.
+description: Every symbol exported by ranuts — 402 exports across 6 entry points, with signatures and descriptions.
 ---
 
 # ranuts API (Generated)
@@ -13,11 +13,11 @@ constraints, conventions) read [CLAUDE.md](https://github.com/chaxus/ran/blob/ma
 Import from the **subpath** that owns the symbol, e.g. `import { debounce } from
 'ranuts/utils'`. The root `ranuts` barrel re-exports the utils + visual surface.
 
-**393 exports** across 6 entry points. Generated at 2026-08-13T14:02:17.188Z.
+**402 exports** across 6 entry points. Generated at 2026-08-17T14:42:17.466Z.
 
 ## Entry points
 
-- [`ranuts/utils`](#ranuts-utils) — Browser and general-purpose utilities · _browser + node_ · 307 exports
+- [`ranuts/utils`](#ranuts-utils) — Browser and general-purpose utilities · _browser + node_ · 316 exports
 - [`ranuts/sw`](#ranuts-sw) — Service Worker caching strategies and the precache protocol · _service worker only_ · 9 exports
 - [`ranuts/node`](#ranuts-node) — Node server utilities (fs / http / ws / middleware) · _node only_ · 26 exports
 - [`ranuts/visual`](#ranuts-visual) — 2D rendering engine (Canvas / WebGL / WebGPU) · _browser only_ · 16 exports
@@ -42,11 +42,13 @@ import { /* … */ } from 'ranuts/utils';
 - `appendUrl(url: string, params?: Record<string, string>) => string` — Turn an object into a query string and append it to a URL
 - `arrayBufferToString(buffer: ArrayBuffer | Uint8Array) => string` — Decode bytes into a string using the sniffed encoding. Required when reading
 - `autosizeTextarea(element: HTMLTextAreaElement) => (() => void)` — Make a `<textarea>` grow and shrink with its content, so a long message is
+- `base64ToBytes(base64: string) => Uint8Array<ArrayBuffer>` — Decode base64 into bytes. Accepts a bare payload or a full
 - `blendMultiply(base: RGB, blend: RGB) => RGB` — Multiply blend of two colours (channel-wise `base * blend`). Channels in 0..1.
 - `blendOverlay(base: RGB, blend: RGB) => RGB` — Overlay blend of two colours (multiply in shadows, screen in highlights). Channels in 0..1.
 - `blendScreen(base: RGB, blend: RGB) => RGB` — Screen blend of two colours (channel-wise `1 - (1 - base)(1 - blend)`). Channels in 0..1.
 - `brightnessContrast(color: RGB, brightness: number, contrast: number) => RGB` — Adjust brightness and contrast of a colour: `(c - 0.5) * contrast + 0.5 + brightness` per channel. Channels in 0..1.
 - `buildOffsets(lengths: readonly number[]) => number[]` — The global start offset of every chunk in the concatenated coordinate
+- `bytesToBase64(data: Uint8Array | ArrayBuffer) => string` — Encode bytes as base64 without blowing the call stack.
 - `checkEncoding(uint8Array: Uint8Array) => string`
 - `clamp(value: number, min: number, max: number) => number` — Clamp `value` into the inclusive range `[min, max]`.
 - `clearBr(str?: string) => string` — Strip whitespace, line breaks and HTML tags out of a string
@@ -76,6 +78,7 @@ import { /* … */ } from 'ranuts/utils';
 - `currentDevice() => CurrentDevice`
 - `cutRound(img: ImgSource, radius: number) => ImgSource` — Round an image's corners, returning an offscreen canvas.
 - `debounce<T extends (...args: any[]) => any>(fn: T, ms?: number) => Debounced<T>` — Debounce — on a burst of calls, run only the last one, **`ms` milliseconds
+- `decodeTextBytes(bytes: Uint8Array, encodings?: string[]) => string` — Decode text bytes, trying encodings in order until one holds.
 - `deferred<T = void>() => Deferred<T>` — A promise plus its `resolve` / `reject`, for the case where the thing that
 - `delay(ms: number) => Promise<void>` — Resolve after `ms` milliseconds. Uses the bare `setTimeout`, so it works in
 - `detectLanguage(text: string, sampleSize?: number) => TextLanguage` — Decide a text's primary language from the ratio of CJK to Latin characters.
@@ -83,6 +86,7 @@ import { /* … */ } from 'ranuts/utils';
 - `encodeUrl(url: string) => string` — Encode a URL to a percent-encoded form, excluding already-encoded sequences.
 - `escapeHtml(string?: string | number | null) => string`
 - `fanShapedByArc(ctx: CanvasRenderingContext2D, maxRadius: number, start: number, end: number, gutter: number) => void` — Trace a pie slice with arc(), including the gutter between slices.
+- `fetchMaybeGzip(input: RequestInfo | URL, init?: RequestInit) => Promise<Uint8Array>` — Fetch a resource that may be delivered gzipped or already
 - `filterObj(obj: Record<string, unknown>, list: Array<string>) => Record<string, unknown>` — Return a new object without the properties whose values appear in `list` — typically used to drop empty strings and nulls
 - `fit(value: number, a1: number, a2: number, b1: number, b2: number) => number` — Remap `value` from `[a1, a2]` onto `[b1, b2]` and clamp to the output range — the shader `fit`.
 - `formatDate(value?: DateInput, pattern?: string) => string` — Format a date with a token pattern. Accepts a timestamp, a date string, a
@@ -108,6 +112,7 @@ import { /* … */ } from 'ranuts/utils';
 - `getStatus(code?: number | string) => number | string | undefined` — Get the status code.
 - `getTangentByPointer(x: number, y: number) => Array<number>` — The tangent line at a point on a circle
 - `getWindow() => ClientRatio` — Get the viewport size across browsers
+- `gunzipMaybe(bytes: Uint8Array) => Promise<Uint8Array>` — Decompress bytes if — and only if — they are still gzipped.
 - `handleConsole(hooks?: (...args: unknown[]) => void) => (() => void)` — Tap into `console` so every call also reaches your hook, while still printing
 - `handleError(hooks?: (error: ErrorPayload) => void) => (() => void)` — Listen for uncaught errors and unhandled promise rejections, in the capture
 - `handleFetchHook(options?: Partial<Options>) => (() => void)` — Instrument `window.fetch` so every request, response and failure reaches your
@@ -129,6 +134,8 @@ import { /* … */ } from 'ranuts/utils';
 - `inflateRaw(data: Uint8Array) => Promise<Uint8Array>` — Decompress raw DEFLATE bytes (no zlib or gzip wrapper) — the form ZIP
 - `inverseLerp(a: number, b: number, value: number) => number` — Inverse of `lerp` — where `value` sits between `a` and `b`, as 0..1. Returns 0 when `a === b`. Not clamped.
 - `isEqual(value: any, other: any, seen?: Map<any, any>) => boolean` — Deep-compare two values.
+- `isGzip(bytes: Uint8Array) => boolean` — Whether the bytes start with the gzip magic number (1f 8b).
+- `isHtmlDocument(bytes: Uint8Array) => boolean` — Whether the bytes are an HTML document rather than the binary
 - `isImageSize(file: File, width?: number, height?: number) => Promise<boolean>` — Check an image's dimensions against a given width / height. When both are
 - `isInIframe() => boolean` — Whether this page is running inside an iframe. Returns false under SSR.
 - `isMobile() => boolean` — Whether this is a mobile device
@@ -137,6 +144,7 @@ import { /* … */ } from 'ranuts/utils';
 - `isString(obj: unknown) => boolean`
 - `isUrlCached(url: string) => Promise<boolean>` — Whether a URL is already in CacheStorage. When probing a group of files,
 - `isWeiXin() => boolean` — Whether this is the WeChat in-app browser
+- `isZipContainer(bytes: Uint8Array) => boolean` — Whether the bytes are a ZIP container (PK\x03\x04) — which is
 - `lerp(a: number, b: number, t: number) => number` — Linear interpolation from `a` to `b` by `t` (t=0 → a, t=1 → b). Not clamped.
 - `linearstep(edge0: number, edge1: number, x: number) => number` — Linear ramp — 0 below `edge0`, 1 above `edge1`, a straight line between (the shader `linearstep`, no smoothing).
 - `linearToSrgb(c: number) => number` — Convert one linear-light channel (0..1) to sRGB.
@@ -196,6 +204,7 @@ import { /* … */ } from 'ranuts/utils';
 - `rgbToHsv(r: number, g: number, b: number) => number[]` — Alias of `rgbToHsb` — HSV and HSB are two names for the same colour space.
 - `roundRectByArc(ctx: CanvasRenderingContext2D, ...[x, y, w, h, r]: number[]) => void` — Trace a rounded rectangle with arc(). A corner radius larger than half the
 - `saturation(color: RGB, amount: number) => RGB` — Adjust saturation by mixing toward the colour's luminance. `amount` 0 = greyscale, 1 = unchanged, >1 = more saturated. Channels in 0..1.
+- `saveFileToDisk(data: Blob | Uint8Array, fileName: string, options?: SaveFileOptions) => Promise<boolean>` — Save bytes to disk: a real "Save as" dialog through the File
 - `scriptOnLoad(urls: string[], append?: HTMLElement, callback?: () => void) => Promise<void>` — Insert script/link tags dynamically
 - `segmentByRanges<T>(text: string, chunkStart: number, ranges: readonly OffsetRange<T>[]) => Segment<T>[]` — Split one chunk of text into a sequence of plain / matched spans according
 - `serveWorker<Req extends WorkerRequestBase, Res extends object = object, Progress = unknown>(handler: (request: Req, context: WorkerHandlerContext<Progress>) =>…` — Serve requests inside a Web Worker, mirroring {@link WorkerClient} on the

--- a/packages/ranui/package.json
+++ b/packages/ranui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ranui",
-  "version": "0.5.0-alpha.2",
+  "version": "0.5.0-alpha.3",
   "description": "A framework-agnostic Web Components UI library built on native custom elements, with TypeScript types, light/dark theming, SSR and PWA support.",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/packages/ranuts/CLAUDE.md
+++ b/packages/ranuts/CLAUDE.md
@@ -58,6 +58,7 @@ packages/ranuts/
 │   │   ├── idb.ts            # WebDB (declarative stores) + createHandoff (one-shot value handoff)
 │   │   ├── worker.ts         # WorkerClient — request/response over a Web Worker
 │   │   ├── zip.ts            # ZIP read/rewrite — crc32, inflateRaw, rewriteZip, createZip
+│   │   ├── binary.ts         # bytes ↔ base64 (chunked), gzip sniff/decompress, zip/HTML signature sniff, decodeTextBytes, saveFileToDisk
 │   │   ├── async.ts          # deferred / withTimeout / withTimeoutFallback / delay / createRaceGuard
 │   │   ├── storage.ts        # localStorage* + createStore (prefixed JSON view)
 │   │   ├── segment.ts        # offsets ↔ chunks, range→segment splitting (highlights)

--- a/packages/ranuts/README.md
+++ b/packages/ranuts/README.md
@@ -10,6 +10,8 @@ Experimental utility library with commonly used functions and tools
 <a href="https://github.com/chaxus/ran"><img src="https://img.badgesize.io/https:/unpkg.com/ranuts/dist/index.js?label=brotli&compression=brotli" alt="brotli"></a>
 <a href="https://github.com/chaxus/ran"><img src="https://img.shields.io/badge/module%20formats-umd%2C%20esm-green.svg" alt="module formats: umd, esm"></a>
 
+**English** | [中文](./README.zh-CN.md)
+
 ---
 
 ## ⚠️ Important Notice
@@ -53,9 +55,11 @@ Claude then uses it automatically (or invoke it as `/ranuts:ranuts`).
 
 Import as required. You can select:
 
-- `ranuts/utils` — DOM/BOM, string, object, number, colour, time, storage, i18n helpers
+- `ranuts/utils` — DOM/BOM, string, object, number, colour, time, storage, binary/zip,
+  worker/IndexedDB, i18n helpers
 - `ranuts/node` — HTTP server, router, ws, fs, streams, middleware (**Node only**)
 - `ranuts/visual` — 2D rendering engine (Canvas / WebGL / WebGPU, **browser only**)
+- `ranuts/sw` — cache strategies + the precache protocol's service-worker half (**service worker only**)
 - `ranuts/vnode` — Snabbdom-style virtual DOM
 - `ranuts/i18n` — the i18n engine on its own, without the rest of `utils`
 

--- a/packages/ranuts/README.zh-CN.md
+++ b/packages/ranuts/README.zh-CN.md
@@ -36,13 +36,29 @@ npm install ranuts@latest --save
 
 [一些常用的函数和工具](https://ran.chaxus.com/cn/src/ranuts/)
 
+**面向 AI / 大模型：** 从 [CLAUDE.md](./CLAUDE.md)（入口点、运行时约束、代码约定）和
+[docs/API.md](./docs/API.md)（自动生成的 API 参考，含每个导出符号的签名与说明，用
+`npm run doc:api` 重新生成）开始。
+
+也可以从 `ran` 插件市场安装现成的 **Claude Code skill**，它会把导入映射、`ranuts/utils`
+清单、用法示例和代码约定交给助手，并指向包内附带的 API 参考：
+
+```bash
+/plugin marketplace add chaxus/ran
+/plugin install ranuts@ran
+```
+
+装好后 Claude 会自动使用（也可以手动调用 `/ranuts:ranuts`）。
+
 ## 使用方式
 
 按需导入。您可以选择：
 
-- `ranuts/utils` —— DOM/BOM、字符串、对象、数字、颜色、时间、存储、i18n 等工具
+- `ranuts/utils` —— DOM/BOM、字符串、对象、数字、颜色、时间、存储、二进制/zip、
+  Worker/IndexedDB、i18n 等工具
 - `ranuts/node` —— HTTP 服务、路由、ws、fs、流、中间件（**仅 Node**）
 - `ranuts/visual` —— 2D 渲染引擎（Canvas / WebGL / WebGPU，**仅浏览器**）
+- `ranuts/sw` —— 缓存策略 + 预缓存协议的 Service Worker 一侧（**仅 Service Worker**）
 - `ranuts/vnode` —— Snabbdom 风格的虚拟 DOM
 - `ranuts/i18n` —— 单独的 i18n 引擎，不牵入 `utils` 的其余部分
 

--- a/packages/ranuts/docs/API.md
+++ b/packages/ranuts/docs/API.md
@@ -8,11 +8,11 @@ constraints, conventions) read [../CLAUDE.md](../CLAUDE.md) first.
 Import from the **subpath** that owns the symbol, e.g. `import { debounce } from
 'ranuts/utils'`. The root `ranuts` barrel re-exports the utils + visual surface.
 
-**393 exports** across 6 entry points. Generated at 2026-08-13T14:02:17.188Z.
+**402 exports** across 6 entry points. Generated at 2026-08-17T14:42:17.466Z.
 
 ## Entry points
 
-- [`ranuts/utils`](#ranuts-utils) — Browser and general-purpose utilities · _browser + node_ · 307 exports
+- [`ranuts/utils`](#ranuts-utils) — Browser and general-purpose utilities · _browser + node_ · 316 exports
 - [`ranuts/sw`](#ranuts-sw) — Service Worker caching strategies and the precache protocol · _service worker only_ · 9 exports
 - [`ranuts/node`](#ranuts-node) — Node server utilities (fs / http / ws / middleware) · _node only_ · 26 exports
 - [`ranuts/visual`](#ranuts-visual) — 2D rendering engine (Canvas / WebGL / WebGPU) · _browser only_ · 16 exports
@@ -37,11 +37,13 @@ import { /* … */ } from 'ranuts/utils';
 - `appendUrl(url: string, params?: Record<string, string>) => string` — Turn an object into a query string and append it to a URL
 - `arrayBufferToString(buffer: ArrayBuffer | Uint8Array) => string` — Decode bytes into a string using the sniffed encoding. Required when reading
 - `autosizeTextarea(element: HTMLTextAreaElement) => (() => void)` — Make a `<textarea>` grow and shrink with its content, so a long message is
+- `base64ToBytes(base64: string) => Uint8Array<ArrayBuffer>` — Decode base64 into bytes. Accepts a bare payload or a full
 - `blendMultiply(base: RGB, blend: RGB) => RGB` — Multiply blend of two colours (channel-wise `base * blend`). Channels in 0..1.
 - `blendOverlay(base: RGB, blend: RGB) => RGB` — Overlay blend of two colours (multiply in shadows, screen in highlights). Channels in 0..1.
 - `blendScreen(base: RGB, blend: RGB) => RGB` — Screen blend of two colours (channel-wise `1 - (1 - base)(1 - blend)`). Channels in 0..1.
 - `brightnessContrast(color: RGB, brightness: number, contrast: number) => RGB` — Adjust brightness and contrast of a colour: `(c - 0.5) * contrast + 0.5 + brightness` per channel. Channels in 0..1.
 - `buildOffsets(lengths: readonly number[]) => number[]` — The global start offset of every chunk in the concatenated coordinate
+- `bytesToBase64(data: Uint8Array | ArrayBuffer) => string` — Encode bytes as base64 without blowing the call stack.
 - `checkEncoding(uint8Array: Uint8Array) => string`
 - `clamp(value: number, min: number, max: number) => number` — Clamp `value` into the inclusive range `[min, max]`.
 - `clearBr(str?: string) => string` — Strip whitespace, line breaks and HTML tags out of a string
@@ -71,6 +73,7 @@ import { /* … */ } from 'ranuts/utils';
 - `currentDevice() => CurrentDevice`
 - `cutRound(img: ImgSource, radius: number) => ImgSource` — Round an image's corners, returning an offscreen canvas.
 - `debounce<T extends (...args: any[]) => any>(fn: T, ms?: number) => Debounced<T>` — Debounce — on a burst of calls, run only the last one, **`ms` milliseconds
+- `decodeTextBytes(bytes: Uint8Array, encodings?: string[]) => string` — Decode text bytes, trying encodings in order until one holds.
 - `deferred<T = void>() => Deferred<T>` — A promise plus its `resolve` / `reject`, for the case where the thing that
 - `delay(ms: number) => Promise<void>` — Resolve after `ms` milliseconds. Uses the bare `setTimeout`, so it works in
 - `detectLanguage(text: string, sampleSize?: number) => TextLanguage` — Decide a text's primary language from the ratio of CJK to Latin characters.
@@ -78,6 +81,7 @@ import { /* … */ } from 'ranuts/utils';
 - `encodeUrl(url: string) => string` — Encode a URL to a percent-encoded form, excluding already-encoded sequences.
 - `escapeHtml(string?: string | number | null) => string`
 - `fanShapedByArc(ctx: CanvasRenderingContext2D, maxRadius: number, start: number, end: number, gutter: number) => void` — Trace a pie slice with arc(), including the gutter between slices.
+- `fetchMaybeGzip(input: RequestInfo | URL, init?: RequestInit) => Promise<Uint8Array>` — Fetch a resource that may be delivered gzipped or already
 - `filterObj(obj: Record<string, unknown>, list: Array<string>) => Record<string, unknown>` — Return a new object without the properties whose values appear in `list` — typically used to drop empty strings and nulls
 - `fit(value: number, a1: number, a2: number, b1: number, b2: number) => number` — Remap `value` from `[a1, a2]` onto `[b1, b2]` and clamp to the output range — the shader `fit`.
 - `formatDate(value?: DateInput, pattern?: string) => string` — Format a date with a token pattern. Accepts a timestamp, a date string, a
@@ -103,6 +107,7 @@ import { /* … */ } from 'ranuts/utils';
 - `getStatus(code?: number | string) => number | string | undefined` — Get the status code.
 - `getTangentByPointer(x: number, y: number) => Array<number>` — The tangent line at a point on a circle
 - `getWindow() => ClientRatio` — Get the viewport size across browsers
+- `gunzipMaybe(bytes: Uint8Array) => Promise<Uint8Array>` — Decompress bytes if — and only if — they are still gzipped.
 - `handleConsole(hooks?: (...args: unknown[]) => void) => (() => void)` — Tap into `console` so every call also reaches your hook, while still printing
 - `handleError(hooks?: (error: ErrorPayload) => void) => (() => void)` — Listen for uncaught errors and unhandled promise rejections, in the capture
 - `handleFetchHook(options?: Partial<Options>) => (() => void)` — Instrument `window.fetch` so every request, response and failure reaches your
@@ -124,6 +129,8 @@ import { /* … */ } from 'ranuts/utils';
 - `inflateRaw(data: Uint8Array) => Promise<Uint8Array>` — Decompress raw DEFLATE bytes (no zlib or gzip wrapper) — the form ZIP
 - `inverseLerp(a: number, b: number, value: number) => number` — Inverse of `lerp` — where `value` sits between `a` and `b`, as 0..1. Returns 0 when `a === b`. Not clamped.
 - `isEqual(value: any, other: any, seen?: Map<any, any>) => boolean` — Deep-compare two values.
+- `isGzip(bytes: Uint8Array) => boolean` — Whether the bytes start with the gzip magic number (1f 8b).
+- `isHtmlDocument(bytes: Uint8Array) => boolean` — Whether the bytes are an HTML document rather than the binary
 - `isImageSize(file: File, width?: number, height?: number) => Promise<boolean>` — Check an image's dimensions against a given width / height. When both are
 - `isInIframe() => boolean` — Whether this page is running inside an iframe. Returns false under SSR.
 - `isMobile() => boolean` — Whether this is a mobile device
@@ -132,6 +139,7 @@ import { /* … */ } from 'ranuts/utils';
 - `isString(obj: unknown) => boolean`
 - `isUrlCached(url: string) => Promise<boolean>` — Whether a URL is already in CacheStorage. When probing a group of files,
 - `isWeiXin() => boolean` — Whether this is the WeChat in-app browser
+- `isZipContainer(bytes: Uint8Array) => boolean` — Whether the bytes are a ZIP container (PK\x03\x04) — which is
 - `lerp(a: number, b: number, t: number) => number` — Linear interpolation from `a` to `b` by `t` (t=0 → a, t=1 → b). Not clamped.
 - `linearstep(edge0: number, edge1: number, x: number) => number` — Linear ramp — 0 below `edge0`, 1 above `edge1`, a straight line between (the shader `linearstep`, no smoothing).
 - `linearToSrgb(c: number) => number` — Convert one linear-light channel (0..1) to sRGB.
@@ -191,6 +199,7 @@ import { /* … */ } from 'ranuts/utils';
 - `rgbToHsv(r: number, g: number, b: number) => number[]` — Alias of `rgbToHsb` — HSV and HSB are two names for the same colour space.
 - `roundRectByArc(ctx: CanvasRenderingContext2D, ...[x, y, w, h, r]: number[]) => void` — Trace a rounded rectangle with arc(). A corner radius larger than half the
 - `saturation(color: RGB, amount: number) => RGB` — Adjust saturation by mixing toward the colour's luminance. `amount` 0 = greyscale, 1 = unchanged, >1 = more saturated. Channels in 0..1.
+- `saveFileToDisk(data: Blob | Uint8Array, fileName: string, options?: SaveFileOptions) => Promise<boolean>` — Save bytes to disk: a real "Save as" dialog through the File
 - `scriptOnLoad(urls: string[], append?: HTMLElement, callback?: () => void) => Promise<void>` — Insert script/link tags dynamically
 - `segmentByRanges<T>(text: string, chunkStart: number, ranges: readonly OffsetRange<T>[]) => Segment<T>[]` — Split one chunk of text into a sequence of plain / matched spans according
 - `serveWorker<Req extends WorkerRequestBase, Res extends object = object, Progress = unknown>(handler: (request: Req, context: WorkerHandlerContext<Progress>) =>…` — Serve requests inside a Web Worker, mirroring {@link WorkerClient} on the

--- a/packages/ranuts/package.json
+++ b/packages/ranuts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ranuts",
-  "version": "0.4.0-alpha.4",
+  "version": "0.4.0-alpha.5",
   "description": "Tree-shakeable TypeScript utility library: DOM/BOM helpers, string/object/number/color utils, debounce/throttle/compose, a 2D rendering engine and a virtual DOM.",
   "main": "dist/index.umd.cjs",
   "module": "dist/index.js",

--- a/packages/ranuts/src/utils/binary.ts
+++ b/packages/ranuts/src/utils/binary.ts
@@ -1,0 +1,211 @@
+/**
+ * Binary payload helpers: base64 without the call-stack trap, gzip that may or
+ * may not already be decoded, byte-signature sniffing, text decoding with an
+ * encoding fallback chain, and "save these bytes to disk".
+ *
+ * All of these were written (several times each) inside apps that move file
+ * bytes around — an Office editor, a converter, a downloader — before landing
+ * here.
+ */
+
+/**
+ * @description: Encode bytes as base64 without blowing the call stack.
+ *
+ * `String.fromCharCode.apply(null, bytes)` is the usual one-liner and it throws
+ * `RangeError: Maximum call stack size exceeded` somewhere around a hundred
+ * thousand bytes — a limit real files pass routinely, so the naive version
+ * works in every test and fails on the first user document. Chunked here.
+ *
+ * @param {Uint8Array | ArrayBuffer} data
+ * @return {string} base64 (no data: prefix, no line breaks)
+ */
+export const bytesToBase64 = (data: Uint8Array | ArrayBuffer): string => {
+  const bytes = data instanceof Uint8Array ? data : new Uint8Array(data);
+  const CHUNK = 0x8000;
+  let binary = '';
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    binary += String.fromCharCode.apply(null, Array.from(bytes.subarray(i, i + CHUNK)));
+  }
+  return btoa(binary);
+};
+
+/**
+ * @description: Decode base64 into bytes. Accepts a bare payload or a full
+ * `data:` URL (the prefix is stripped), which is what `readFileAsDataURL` and
+ * canvas `toDataURL` hand you.
+ *
+ * @param {string} base64
+ * @return {Uint8Array}
+ */
+export const base64ToBytes = (base64: string): Uint8Array<ArrayBuffer> => {
+  const payload = base64.startsWith('data:') ? base64.slice(base64.indexOf(',') + 1) : base64;
+  const binary = atob(payload);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+};
+
+/** @description: Whether the bytes start with the gzip magic number (1f 8b). */
+export const isGzip = (bytes: Uint8Array): boolean => bytes.length >= 2 && bytes[0] === 0x1f && bytes[1] === 0x8b;
+
+/**
+ * @description: Whether the bytes are a ZIP container (PK\x03\x04) — which is
+ * also every OOXML file (docx / xlsx / pptx), ODF file, epub and jar.
+ */
+export const isZipContainer = (bytes: Uint8Array): boolean =>
+  bytes.length >= 4 && bytes[0] === 0x50 && bytes[1] === 0x4b && bytes[2] === 0x03 && bytes[3] === 0x04;
+
+/**
+ * @description: Whether the bytes are an HTML document rather than the binary
+ * format their extension claims.
+ *
+ * Web systems love exporting an HTML `<table>` under a `.xls` name; spreadsheet
+ * apps accept it, parsers that trust the extension do not. A leading BOM and
+ * whitespace are skipped, and a ZIP container short-circuits to `false` so a
+ * real .xlsx is never sniffed as HTML.
+ */
+export const isHtmlDocument = (bytes: Uint8Array): boolean => {
+  if (bytes.length < 8 || isZipContainer(bytes)) return false;
+  const start = bytes[0] === 0xef && bytes[1] === 0xbb && bytes[2] === 0xbf ? 3 : 0;
+  const head = new TextDecoder('latin1').decode(bytes.subarray(start, start + 2048)).replace(/^\s+/, '');
+  return /^<(!doctype\s+html|html|head|body|table|meta|\?xml[^>]*>\s*<html)/i.test(head);
+};
+
+/**
+ * @description: Decompress bytes if — and only if — they are still gzipped.
+ *
+ * A server that sends `Content-Encoding: gzip` has the browser decode the body
+ * before you ever see it, while a `.gz` file served as `application/gzip`
+ * arrives compressed. The same fetch therefore yields either shape depending on
+ * the host, so the magic number decides instead of the URL.
+ *
+ * @param {Uint8Array} bytes
+ * @return {Promise<Uint8Array>} the original bytes when they are not gzipped
+ */
+export const gunzipMaybe = async (bytes: Uint8Array): Promise<Uint8Array> => {
+  if (!isGzip(bytes)) return bytes;
+  if (typeof DecompressionStream === 'undefined') {
+    throw new Error('DecompressionStream is not available in this runtime');
+  }
+  const stream = new Response(bytes as Uint8Array<ArrayBuffer>).body!.pipeThrough(new DecompressionStream('gzip'));
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+};
+
+/**
+ * @description: Fetch a resource that may be delivered gzipped or already
+ * decoded (see `gunzipMaybe`), e.g. a large `.wasm.gz` asset on a static host.
+ *
+ * @param {RequestInfo | URL} input
+ * @param {RequestInit} init
+ * @return {Promise<Uint8Array>}
+ */
+export const fetchMaybeGzip = async (input: RequestInfo | URL, init?: RequestInit): Promise<Uint8Array> => {
+  const response = await fetch(input, init);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch '${String(input)}' (${response.status} ${response.statusText})`);
+  }
+  return gunzipMaybe(new Uint8Array(await response.arrayBuffer()));
+};
+
+/**
+ * @description: Decode text bytes, trying encodings in order until one holds.
+ *
+ * A non-fatal `TextDecoder` never throws — invalid sequences silently become
+ * U+FFFD — so a legacy-encoded file decodes "successfully" into mojibake. Strict
+ * decoding is the only way to tell, so each candidate is tried with
+ * `fatal: true` and the last one is the fallback that cannot fail. The default
+ * chain covers a UTF-8 BOM, real UTF-8, Chinese "ANSI" exports (GB18030 is a
+ * superset of GBK) and finally latin1.
+ *
+ * Pair with `checkEncoding` when you would rather detect statistically than
+ * fall through a fixed list.
+ *
+ * @param {Uint8Array} bytes
+ * @param {string[]} encodings candidates, most specific first
+ * @return {string}
+ */
+export const decodeTextBytes = (bytes: Uint8Array, encodings: string[] = ['utf-8', 'gb18030', 'latin1']): string => {
+  if (bytes.length >= 3 && bytes[0] === 0xef && bytes[1] === 0xbb && bytes[2] === 0xbf) {
+    return new TextDecoder('utf-8').decode(bytes.subarray(3));
+  }
+  for (let i = 0; i < encodings.length; i++) {
+    const last = i === encodings.length - 1;
+    try {
+      return new TextDecoder(encodings[i], { fatal: !last }).decode(bytes);
+    } catch {
+      // not this encoding (or the decoder is unavailable): try the next one
+    }
+  }
+  return new TextDecoder('latin1').decode(bytes);
+};
+
+interface SaveFileOptions {
+  /** MIME type for the picker's file-type entry and the Blob. */
+  mimeType?: string;
+  /** Human-readable type description shown by the save dialog. */
+  description?: string;
+}
+
+type SaveFilePicker = (options: {
+  suggestedName: string;
+  types: Array<{ description: string; accept: Record<string, string[]> }>;
+}) => Promise<{ createWritable: () => Promise<{ write: (data: Blob | Uint8Array) => Promise<void>; close: () => Promise<void> }> }>;
+
+/**
+ * @description: Save bytes to disk: a real "Save as" dialog through the File
+ * System Access API where it exists, an anchor download everywhere else.
+ *
+ * Resolves `true` when the file was written, `false` when the user dismissed
+ * the picker — a cancel is not an error, and callers that treat it as one end
+ * up showing a failure toast for a deliberate action. Anything else rejects.
+ *
+ * @param {Blob | Uint8Array} data
+ * @param {string} fileName
+ * @param {SaveFileOptions} options
+ * @return {Promise<boolean>} whether the file was written
+ */
+export const saveFileToDisk = async (
+  data: Blob | Uint8Array,
+  fileName: string,
+  options: SaveFileOptions = {},
+): Promise<boolean> => {
+  const blob = data instanceof Blob ? data : new Blob([data as Uint8Array<ArrayBuffer>], { type: options.mimeType });
+  const picker = (globalThis as unknown as { showSaveFilePicker?: SaveFilePicker }).showSaveFilePicker;
+
+  if (typeof picker === 'function') {
+    const extension = fileName.includes('.') ? `.${fileName.split('.').pop()}` : '';
+    try {
+      const handle = await picker({
+        suggestedName: fileName,
+        types: [
+          {
+            description: options.description || 'File',
+            accept: { [options.mimeType || blob.type || 'application/octet-stream']: extension ? [extension] : [] },
+          },
+        ],
+      });
+      const writable = await handle.createWritable();
+      await writable.write(blob);
+      await writable.close();
+      return true;
+    } catch (error) {
+      // The user dismissing the dialog is a normal outcome, not a failure.
+      if ((error as Error)?.name === 'AbortError') return false;
+      throw error;
+    }
+  }
+
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = fileName;
+  link.style.display = 'none';
+  document.body.appendChild(link);
+  link.click();
+  // Revoking synchronously can cancel the download in some browsers.
+  setTimeout(() => {
+    link.remove();
+    URL.revokeObjectURL(url);
+  }, 100);
+  return true;
+};

--- a/packages/ranuts/src/utils/binary.ts
+++ b/packages/ranuts/src/utils/binary.ts
@@ -149,7 +149,9 @@ interface SaveFileOptions {
 type SaveFilePicker = (options: {
   suggestedName: string;
   types: Array<{ description: string; accept: Record<string, string[]> }>;
-}) => Promise<{ createWritable: () => Promise<{ write: (data: Blob | Uint8Array) => Promise<void>; close: () => Promise<void> }> }>;
+}) => Promise<{
+  createWritable: () => Promise<{ write: (data: Blob | Uint8Array) => Promise<void>; close: () => Promise<void> }>;
+}>;
 
 /**
  * @description: Save bytes to disk: a real "Save as" dialog through the File

--- a/packages/ranuts/src/utils/index.ts
+++ b/packages/ranuts/src/utils/index.ts
@@ -141,6 +141,17 @@ import { computePlacement } from './placement';
 import type { ComputePlacementOptions, ComputedPlacement, Placement, PlacementRect } from './placement';
 import type { ResolveLocaleOptions, TextLanguage } from './lang';
 import { readFileAsArrayBuffer, readFileAsDataURL, readFileAsText, readFileAsUint8Array } from './file';
+import {
+  base64ToBytes,
+  bytesToBase64,
+  decodeTextBytes,
+  fetchMaybeGzip,
+  gunzipMaybe,
+  isGzip,
+  isHtmlDocument,
+  isZipContainer,
+  saveFileToDisk,
+} from './binary';
 import { WorkerClient, serveWorker } from './worker';
 import type {
   ServeWorkerOptions,
@@ -382,6 +393,15 @@ export {
   resolveLocale,
   readFileAsArrayBuffer,
   readFileAsUint8Array,
+  base64ToBytes,
+  bytesToBase64,
+  decodeTextBytes,
+  fetchMaybeGzip,
+  gunzipMaybe,
+  isGzip,
+  isHtmlDocument,
+  isZipContainer,
+  saveFileToDisk,
   readFileAsText,
   readFileAsDataURL,
   WorkerClient,

--- a/packages/ranuts/test/binary.test.ts
+++ b/packages/ranuts/test/binary.test.ts
@@ -1,0 +1,176 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import {
+  base64ToBytes,
+  bytesToBase64,
+  decodeTextBytes,
+  fetchMaybeGzip,
+  gunzipMaybe,
+  isGzip,
+  isHtmlDocument,
+  isZipContainer,
+  saveFileToDisk,
+} from '@/utils/binary';
+
+const enc = (text: string): Uint8Array => new TextEncoder().encode(text);
+
+const gzip = async (bytes: Uint8Array): Promise<Uint8Array> => {
+  const stream = new Response(bytes as Uint8Array<ArrayBuffer>).body!.pipeThrough(new CompressionStream('gzip'));
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+};
+
+describe('bytesToBase64 / base64ToBytes', () => {
+  it('round-trips arbitrary bytes', () => {
+    const bytes = new Uint8Array([0, 1, 2, 250, 251, 255, 65, 66]);
+    expect(base64ToBytes(bytesToBase64(bytes))).toEqual(bytes);
+  });
+
+  it('accepts an ArrayBuffer as well as a view', () => {
+    const bytes = enc('hello 世界');
+    expect(bytesToBase64(bytes.buffer as ArrayBuffer)).toBe(bytesToBase64(bytes));
+  });
+
+  it('survives a payload far past the call-stack limit of the naive one-liner', () => {
+    const big = new Uint8Array(600_000);
+    for (let i = 0; i < big.length; i++) big[i] = i % 256;
+    expect(() => String.fromCharCode.apply(null, Array.from(big))).toThrow();
+    expect(base64ToBytes(bytesToBase64(big))).toEqual(big);
+  });
+
+  it('strips a data: URL prefix when decoding', () => {
+    const base64 = bytesToBase64(enc('inline'));
+    expect(new TextDecoder().decode(base64ToBytes(`data:text/plain;base64,${base64}`))).toBe('inline');
+  });
+});
+
+describe('signature sniffing', () => {
+  const ZIP = new Uint8Array([0x50, 0x4b, 0x03, 0x04, 0x14, 0x00, 0x06, 0x00]);
+
+  it('recognizes zip containers and gzip streams', () => {
+    expect(isZipContainer(ZIP)).toBe(true);
+    expect(isZipContainer(enc('not a zip'))).toBe(false);
+    expect(isGzip(new Uint8Array([0x1f, 0x8b, 0x08]))).toBe(true);
+    expect(isGzip(ZIP)).toBe(false);
+  });
+
+  it('recognizes HTML masquerading as a spreadsheet, BOM and leading space included', () => {
+    expect(isHtmlDocument(enc('<html><body><table><tr><td>1</td></tr></table></body></html>'))).toBe(true);
+    expect(isHtmlDocument(enc('  \n<!DOCTYPE html><html>'))).toBe(true);
+    expect(isHtmlDocument(new Uint8Array([0xef, 0xbb, 0xbf, ...enc('<table><tr><td>x</td></tr></table>')]))).toBe(true);
+  });
+
+  it('does not flag real archives, CSV text or short buffers', () => {
+    expect(isHtmlDocument(ZIP)).toBe(false);
+    expect(isHtmlDocument(enc('name,age\n<b>,20\n'))).toBe(false);
+    expect(isHtmlDocument(enc('<td>'))).toBe(false);
+    expect(isHtmlDocument(new Uint8Array(0))).toBe(false);
+  });
+});
+
+describe('gunzipMaybe / fetchMaybeGzip', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('decompresses gzipped bytes and passes plain bytes through untouched', async () => {
+    const plain = enc('the quick brown fox');
+    expect(new TextDecoder().decode(await gunzipMaybe(await gzip(plain)))).toBe('the quick brown fox');
+    const passthrough = await gunzipMaybe(plain);
+    expect(passthrough).toBe(plain);
+  });
+
+  it('fetches and decompresses only when the body is still gzipped', async () => {
+    const payload = enc('wasm bytes');
+    const compressed = await gzip(payload);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(compressed as Uint8Array<ArrayBuffer>, { status: 200 })),
+    );
+    expect(new TextDecoder().decode(await fetchMaybeGzip('/x2t.wasm.gz'))).toBe('wasm bytes');
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(payload as Uint8Array<ArrayBuffer>, { status: 200 })),
+    );
+    expect(new TextDecoder().decode(await fetchMaybeGzip('/x2t.wasm.gz'))).toBe('wasm bytes');
+  });
+
+  it('rejects a non-ok response with the status in the message', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('nope', { status: 404, statusText: 'Not Found' })),
+    );
+    await expect(fetchMaybeGzip('/missing.gz')).rejects.toThrow(/404/);
+  });
+});
+
+describe('decodeTextBytes', () => {
+  it('strips a UTF-8 BOM', () => {
+    expect(decodeTextBytes(new Uint8Array([0xef, 0xbb, 0xbf, ...enc('a,b')]))).toBe('a,b');
+  });
+
+  it('decodes UTF-8 without touching the fallbacks', () => {
+    expect(decodeTextBytes(enc('中文测试'))).toBe('中文测试');
+  });
+
+  it('falls back to GB18030 for legacy "ANSI" exports instead of producing mojibake', () => {
+    // 中文 in GBK: 中 = D6D0, 文 = CEC4 (invalid as UTF-8, so the strict pass rejects it)
+    const gbk = new Uint8Array([0xd6, 0xd0, 0xce, 0xc4]);
+    expect(decodeTextBytes(gbk)).toBe('中文');
+  });
+
+  it('never throws on bytes that are valid in no candidate encoding', () => {
+    const junk = new Uint8Array([0xff, 0xfe, 0x00, 0x80, 0x81]);
+    expect(typeof decodeTextBytes(junk)).toBe('string');
+  });
+});
+
+describe('saveFileToDisk', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    document.body.innerHTML = '';
+  });
+
+  it('writes through the File System Access API when available', async () => {
+    const write = vi.fn(async () => {});
+    const close = vi.fn(async () => {});
+    const picker = vi.fn(async () => ({ createWritable: async () => ({ write, close }) }));
+    vi.stubGlobal('showSaveFilePicker', picker);
+
+    await expect(saveFileToDisk(enc('bytes'), 'report.docx', { mimeType: 'application/msword' })).resolves.toBe(true);
+    expect(picker).toHaveBeenCalledWith(
+      expect.objectContaining({
+        suggestedName: 'report.docx',
+        types: [expect.objectContaining({ accept: { 'application/msword': ['.docx'] } })],
+      }),
+    );
+    expect(write).toHaveBeenCalled();
+    expect(close).toHaveBeenCalled();
+  });
+
+  it('reports a dismissed dialog as "not written" rather than an error', async () => {
+    const abort = Object.assign(new Error('aborted'), { name: 'AbortError' });
+    vi.stubGlobal(
+      'showSaveFilePicker',
+      vi.fn(async () => {
+        throw abort;
+      }),
+    );
+    await expect(saveFileToDisk(enc('bytes'), 'x.txt')).resolves.toBe(false);
+  });
+
+  it('falls back to an anchor download when the picker is unavailable', async () => {
+    vi.stubGlobal('showSaveFilePicker', undefined);
+    vi.stubGlobal('URL', { ...URL, createObjectURL: vi.fn(() => 'blob:x'), revokeObjectURL: vi.fn() });
+    const clicked: string[] = [];
+    const create = document.createElement.bind(document);
+    vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+      const el = create(tag);
+      if (tag === 'a') el.click = () => clicked.push((el as HTMLAnchorElement).download);
+      return el;
+    });
+
+    await expect(saveFileToDisk(enc('bytes'), 'fallback.csv', { mimeType: 'text/csv' })).resolves.toBe(true);
+    expect(clicked).toEqual(['fallback.csv']);
+  });
+});

--- a/packages/ranuts/tsconfig.json
+++ b/packages/ranuts/tsconfig.json
@@ -8,6 +8,8 @@
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "outDir": "dist",
+    "declaration": true,
+    "emitDeclarationOnly": true,
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "isolatedModules": false,


### PR DESCRIPTION
Five utilities extracted from the document editor (edit.chaxus.com), each of which existed there in one to nine hand-written copies:

| util | why it belongs here |
| --- | --- |
| `bytesToBase64` / `base64ToBytes` | the usual `String.fromCharCode.apply(null, bytes)` throws `RangeError` past ~100 KB — passes every test, fails on the first real file. `str.ts` still contains that unchunked pattern. |
| `isGzip` / `gunzipMaybe` / `fetchMaybeGzip` | a `.gz` asset arrives compressed or already decoded depending on the host's `Content-Encoding`, so the magic number must decide, not the URL. |
| `isZipContainer` / `isHtmlDocument` | byte sniffing for "this `.xls` is really an HTML `<table>`" — a very common export shape that breaks extension-trusting parsers. |
| `decodeTextBytes` | a non-fatal `TextDecoder` never throws, so legacy encodings decode into mojibake; strict passes with a BOM → utf-8 → gb18030 → latin1 chain. Complements the statistical `checkEncoding`. |
| `saveFileToDisk` | File System Access API with an anchor fallback; a dismissed dialog resolves `false` instead of rejecting. |

17 new tests (jsdom); full suite 765 passing; API docs regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)