### PR TITLE
feat(ranuts): streaming-conversation primitives — ranuts/stream and createBottomFollower

### DIFF
--- a/packages/docs/cn/src/ranuts/api.md
+++ b/packages/docs/cn/src/ranuts/api.md
@@ -1,6 +1,6 @@
 ---
 title: ranuts API 参考
-description: ranuts 导出的全部符号 — 6 个入口点，共 413 个导出，含签名与描述。
+description: ranuts 导出的全部符号 — 7 个入口点，共 431 个导出，含签名与描述。
 ---
 
 # ranuts API（自动生成）
@@ -12,16 +12,17 @@ description: ranuts 导出的全部符号 — 6 个入口点，共 413 个导出
 请从符号所属的**子路径**导入，例如 `import { debounce } from
 'ranuts/utils'`。根入口 `ranuts` 重新导出 utils + visual 的全部符号。
 
-**413 个导出**，共 6 个入口点。
+**431 个导出**，共 7 个入口点。
 
 ## 入口点
 
-- [`ranuts/utils`](#ranuts-utils) — 浏览器与通用工具函数 · _浏览器 + node_ · 327 个导出
+- [`ranuts/utils`](#ranuts-utils) — 浏览器与通用工具函数 · _浏览器 + node_ · 330 个导出
 - [`ranuts/sw`](#ranuts-sw) — Service Worker 缓存策略与预缓存协议 · _仅 service worker_ · 9 个导出
 - [`ranuts/node`](#ranuts-node) — Node 服务端工具（fs / http / ws / 中间件） · _仅 node_ · 26 个导出
 - [`ranuts/visual`](#ranuts-visual) — 2D 渲染引擎（Canvas / WebGL / WebGPU） · _仅浏览器_ · 16 个导出
 - [`ranuts/i18n`](#ranuts-i18n) — 框架无关的 i18n 引擎（也从 ranuts/utils 再导出） · _浏览器 + node_ · 9 个导出
 - [`ranuts/vnode`](#ranuts-vnode) — Snabbdom 风格的虚拟 DOM · _浏览器_ · 26 个导出
+- [`ranuts/stream`](#ranuts-stream) — Server-Sent Events 解析与厂商中立的模型流折叠 · _浏览器 + node_ · 15 个导出
 
 ## `ranuts/utils`
 
@@ -64,6 +65,7 @@ import { /* … */ } from 'ranuts/utils';
 - `cosinePalette(t: number, a: RGB, b: RGB, c: RGB, d: RGB) => RGB` — Inigo Quilez cosine gradient palette: `a + b * cos(2π(c·t + d))`. Each of `a,b,c,d` is an RGB triple; `t` is the position 0..1. Returns an RGB triple.
 - `crc32(data: Uint8Array) => number` — CRC32 checksum (IEEE 802.3 polynomial), the one ZIP stores per entry.
 - `create(tagName: string, options?: ElementCreationOptions) => Chain`
+- `createBottomFollower(options: BottomFollowerOptions) => BottomFollower` — Creates a bottom-follow controller for one scrollport.
 - `createData(params?: Record<string, unknown>) => Record<string, unknown>` — Build the standard envelope that accompanies a report — page URL, referrer,
 - `createDocumentFragment(list: Element[]) => DocumentFragment | undefined` — Create a DocumentFragment
 - `createDoubleTapDetector(options?: DoubleTapDetectorOptions) => DoubleTapDetector` — Double-tap detection over raw `(x, y, time)` samples — pointer-type-agnostic,
@@ -268,6 +270,8 @@ import { /* … */ } from 'ranuts/utils';
 
 - `interface AcceptPortBridgeOptions`
 - `interface BeaconPayload`
+- `interface BottomFollower` — Imperative bottom-follow controller.
+- `interface BottomFollowerOptions` — How to construct a follower.
 - `interface BridgeManagerOptions`
 - `interface BroadcastPayload`
 - `interface CallToPayload`
@@ -561,4 +565,36 @@ import { /* … */ } from 'ranuts/vnode';
 ### 命名空间
 
 - `namespace is` — Type guards — array / string / primitive / VNode
+
+## `ranuts/stream`
+
+Server-Sent Events 解析与厂商中立的模型流折叠 · 运行环境：**浏览器 + node** · 源码：`src/stream/index.ts`
+
+```ts
+import { /* … */ } from 'ranuts/stream';
+```
+
+### 函数
+
+- `createStreamAccumulator() => StreamAccumulator` — Creates a fold over one streamed response.
+- `mapEventStream(source: ByteSource, map: (event: ServerSentEvent) => readonly StreamChunk[]) => AsyncGenerator<StreamChunk>` — Maps SSE events onto StreamChunk values using a caller-supplied vendor mapping.
+- `parseEventStream(source: ByteSource) => AsyncGenerator<ServerSentEvent>` — Parses a byte stream as `text/event-stream`.
+
+### 接口
+
+- `interface ReasoningBlock` — Model reasoning, when the provider exposes it. Kept separate from TextBlock
+- `interface ServerSentEvent` — One parsed `text/event-stream` event.
+- `interface StreamAccumulator` — Stateful fold over one response's chunks.
+- `interface StreamSnapshot` — Immutable view of everything received so far.
+- `interface TextBlock` — Assistant prose addressed to the user.
+- `interface TokenUsage` — Token counts reported for one response. Every field is optional: providers differ.
+- `interface ToolCallBlock` — One tool invocation requested by the model.
+
+### 类型
+
+- `type ByteSource` — Anything `for await` can walk that yields byte chunks — a `fetch` body, or a fake.
+- `type ContentBlock` — One completed unit of assistant output.
+- `type ContentBlockType` — Discriminator for the content a block accumulates.
+- `type FinishReason` — Why the response ended.
+- `type StreamChunk` — One normalized event from a streamed response.
 

--- a/packages/docs/src/ranuts/api.md
+++ b/packages/docs/src/ranuts/api.md
@@ -1,6 +1,6 @@
 ---
 title: ranuts API reference
-description: Every symbol exported by ranuts — 413 exports across 6 entry points, with signatures and descriptions.
+description: Every symbol exported by ranuts — 431 exports across 7 entry points, with signatures and descriptions.
 ---
 
 # ranuts API (Generated)
@@ -13,16 +13,17 @@ constraints, conventions) read [CLAUDE.md](https://github.com/chaxus/ran/blob/ma
 Import from the **subpath** that owns the symbol, e.g. `import { debounce } from
 'ranuts/utils'`. The root `ranuts` barrel re-exports the utils + visual surface.
 
-**413 exports** across 6 entry points.
+**431 exports** across 7 entry points.
 
 ## Entry points
 
-- [`ranuts/utils`](#ranuts-utils) — Browser and general-purpose utilities · _browser + node_ · 327 exports
+- [`ranuts/utils`](#ranuts-utils) — Browser and general-purpose utilities · _browser + node_ · 330 exports
 - [`ranuts/sw`](#ranuts-sw) — Service Worker caching strategies and the precache protocol · _service worker only_ · 9 exports
 - [`ranuts/node`](#ranuts-node) — Node server utilities (fs / http / ws / middleware) · _node only_ · 26 exports
 - [`ranuts/visual`](#ranuts-visual) — 2D rendering engine (Canvas / WebGL / WebGPU) · _browser only_ · 16 exports
 - [`ranuts/i18n`](#ranuts-i18n) — Framework-agnostic i18n engine (also re-exported from ranuts/utils) · _browser + node_ · 9 exports
 - [`ranuts/vnode`](#ranuts-vnode) — Snabbdom-style virtual DOM · _browser_ · 26 exports
+- [`ranuts/stream`](#ranuts-stream) — Server-Sent Events parsing and a provider-neutral model-stream fold · _browser + node_ · 15 exports
 
 ## `ranuts/utils`
 
@@ -65,6 +66,7 @@ import { /* … */ } from 'ranuts/utils';
 - `cosinePalette(t: number, a: RGB, b: RGB, c: RGB, d: RGB) => RGB` — Inigo Quilez cosine gradient palette: `a + b * cos(2π(c·t + d))`. Each of `a,b,c,d` is an RGB triple; `t` is the position 0..1. Returns an RGB triple.
 - `crc32(data: Uint8Array) => number` — CRC32 checksum (IEEE 802.3 polynomial), the one ZIP stores per entry.
 - `create(tagName: string, options?: ElementCreationOptions) => Chain`
+- `createBottomFollower(options: BottomFollowerOptions) => BottomFollower` — Creates a bottom-follow controller for one scrollport.
 - `createData(params?: Record<string, unknown>) => Record<string, unknown>` — Build the standard envelope that accompanies a report — page URL, referrer,
 - `createDocumentFragment(list: Element[]) => DocumentFragment | undefined` — Create a DocumentFragment
 - `createDoubleTapDetector(options?: DoubleTapDetectorOptions) => DoubleTapDetector` — Double-tap detection over raw `(x, y, time)` samples — pointer-type-agnostic,
@@ -269,6 +271,8 @@ import { /* … */ } from 'ranuts/utils';
 
 - `interface AcceptPortBridgeOptions`
 - `interface BeaconPayload`
+- `interface BottomFollower` — Imperative bottom-follow controller.
+- `interface BottomFollowerOptions` — How to construct a follower.
 - `interface BridgeManagerOptions`
 - `interface BroadcastPayload`
 - `interface CallToPayload`
@@ -562,4 +566,36 @@ import { /* … */ } from 'ranuts/vnode';
 ### Namespaces
 
 - `namespace is` — Type guards — array / string / primitive / VNode
+
+## `ranuts/stream`
+
+Server-Sent Events parsing and a provider-neutral model-stream fold · runtime: **browser + node** · source: `src/stream/index.ts`
+
+```ts
+import { /* … */ } from 'ranuts/stream';
+```
+
+### Functions
+
+- `createStreamAccumulator() => StreamAccumulator` — Creates a fold over one streamed response.
+- `mapEventStream(source: ByteSource, map: (event: ServerSentEvent) => readonly StreamChunk[]) => AsyncGenerator<StreamChunk>` — Maps SSE events onto StreamChunk values using a caller-supplied vendor mapping.
+- `parseEventStream(source: ByteSource) => AsyncGenerator<ServerSentEvent>` — Parses a byte stream as `text/event-stream`.
+
+### Interfaces
+
+- `interface ReasoningBlock` — Model reasoning, when the provider exposes it. Kept separate from TextBlock
+- `interface ServerSentEvent` — One parsed `text/event-stream` event.
+- `interface StreamAccumulator` — Stateful fold over one response's chunks.
+- `interface StreamSnapshot` — Immutable view of everything received so far.
+- `interface TextBlock` — Assistant prose addressed to the user.
+- `interface TokenUsage` — Token counts reported for one response. Every field is optional: providers differ.
+- `interface ToolCallBlock` — One tool invocation requested by the model.
+
+### Types
+
+- `type ByteSource` — Anything `for await` can walk that yields byte chunks — a `fetch` body, or a fake.
+- `type ContentBlock` — One completed unit of assistant output.
+- `type ContentBlockType` — Discriminator for the content a block accumulates.
+- `type FinishReason` — Why the response ended.
+- `type StreamChunk` — One normalized event from a streamed response.
 

--- a/packages/ranuts/CLAUDE.md
+++ b/packages/ranuts/CLAUDE.md
@@ -37,6 +37,7 @@ Each subpath is an independent, tree-shakeable barrel. Import from the subpath, 
 | `ranuts/i18n`   | `src/utils/i18n.ts`         | `I18nCore` / `createI18n` / `useI18n` — DOM-free    | browser + node     |
 | `ranuts/sw`     | `src/sw/index.ts`           | Cache strategies + the precache protocol's SW half  | **service worker** |
 | `ranuts/vnode`  | `src/vnode/index.ts`        | Snabbdom-style virtual DOM (`h`, `init`, modules)   | browser            |
+| `ranuts/stream` | `src/stream/index.ts`       | SSE parsing + provider-neutral model-stream fold    | browser + node     |
 
 \* `ranuts/utils` is broad: most functions are browser-oriented (touch `window`/`document`),
 but pure helpers (`str`, `obj`, `number`, `compose`, `cloneDeep`, …) run anywhere. Functions
@@ -74,10 +75,12 @@ packages/ranuts/
 │   │   ├── canvas.ts         # Canvas 2D geometry — roundRectByArc, fanShapedByArc, getLinearGradient
 │   │   ├── placement.ts      # computePlacement — flip/shift floating-panel placement (re-exported by ranui/utils/placement)
 │   │   ├── tween.ts          # easing curves (quad/cubic/quart/quint/sine/expo/circ)
+│   │   ├── scroll.ts         # createBottomFollower — follow the floor without fighting the reader
 │   │   ├── visual/           # ranuts/visual — 2D rendering engine (see below)
 │   │   └── totp/             # TOTP + hand-rolled SHA
 │   ├── node/                 # ranuts/node — mini HTTP framework
-│   └── vnode/                # ranuts/vnode — virtual DOM
+│   ├── vnode/                # ranuts/vnode — virtual DOM
+│   └── stream/               # ranuts/stream — SSE + StreamChunk + accumulator
 ├── bin/
 │   ├── build.sh              # build (tsc types + vite es/umd)
 │   └── generate-api-docs.ts  # ⭐ doc:api — emits docs/API.md from source + JSDoc
@@ -126,6 +129,59 @@ in `utils/number.ts`; `srgbToLinear`/`luma`/`blend*`/`saturation`/`cosinePalette
 `utils/color.ts`) are exported from `ranuts/utils` for CPU-side reuse.
 
 ---
+
+## Streaming a model response
+
+`ranuts/stream` is three layers, each usable alone. The split is the point: only the
+middle one is vendor-specific, and it is the one ranuts does **not** ship.
+
+1. `parseEventStream(source)` — bytes → `ServerSentEvent`. Transport only, no model
+   concepts. Handles the parts that bite: a chunk boundary anywhere (including inside a
+   multi-byte character or between `\r` and `\n`), repeated `data:` joined with `\n`, one
+   space stripped after the colon, `:` comment keep-alives, a leading BOM, and a trailing
+   block the server never terminated.
+2. `StreamChunk` — the provider-neutral vocabulary. **You write the mapping** from your
+   provider's event shape onto it; `mapEventStream(source, map)` is the seam, and returning
+   `[]` from the mapping is how a keep-alive or a `[DONE]` sentinel is dropped.
+3. `createStreamAccumulator()` — folds chunks into blocks, so a view reads `snapshot()`,
+   `text()`, `reasoning()`, or `toolCalls()` instead of concatenating deltas itself.
+
+Non-obvious rules the vocabulary encodes:
+
+- **Group by `index`, never by arrival order.** Reasoning and text interleave, and several
+  tool calls open at once.
+- **Tool arguments stay raw JSON text.** Half a JSON document is not a value. The
+  accumulator never parses `argumentsDelta`; parse once, after `finish`.
+- **`block-start` is optional.** Several providers open a block with its first delta, so
+  the accumulator opens one on demand. Do not require it in your mapping either.
+- **`block-end` wins.** When a provider sends an assembled block, it replaces whatever the
+  deltas accumulated.
+- **`finish` terminates.** `usage` arrives before it; nothing after it.
+
+## Following the bottom of a scroller
+
+`createBottomFollower` (from `ranuts/utils`) keeps an append-only view — a streaming
+transcript, a log tail, a terminal — pinned to its floor without fighting the reader.
+
+The hard part is telling your own scroll writes apart from the reader's. It uses an
+**observed-top ledger**: every programmatic write records the `scrollTop` it produced, and
+a scroll event whose position deviates from the ledger is the reader. That covers wheel,
+touch, scrollbar, keyboard and stray `scrollIntoView` calls at once, without listening for
+any input device — no list of device listeners is ever complete.
+
+Using it:
+
+- Call `follow()` whenever content changes; it is a no-op while the reader is scrolled up.
+- Pass `observe: [column]` for growth that appends no node — streaming text grows an
+  existing node, so it has to be observed rather than announced.
+- Before loading older content, `captureAnchor(row)` on a row that is actually on screen,
+  and `restoreAnchor()` after the prepend lands. Resolving to `null` means the row did not
+  survive; omitting the resolver reuses the captured element.
+- A shrink-clamp never transfers ownership. A reader who had scrolled up stays unpinned
+  even when the clamp leaves them at the floor, and re-pins on their next scroll —
+  re-pinning on a clamp would take control back with no input from them.
+- Scrolling is always instant. Smooth scrolling animates toward a moving target during
+  streaming, and its intermediate positions read as reader input on the next event.
 
 ## Conventions
 

--- a/packages/ranuts/README.md
+++ b/packages/ranuts/README.md
@@ -61,6 +61,7 @@ Import as required. You can select:
 - `ranuts/visual` — 2D rendering engine (Canvas / WebGL / WebGPU, **browser only**)
 - `ranuts/sw` — cache strategies + the precache protocol's service-worker half (**service worker only**)
 - `ranuts/vnode` — Snabbdom-style virtual DOM
+- `ranuts/stream` — Server-Sent Events parsing plus a provider-neutral fold of a streamed model response
 - `ranuts/i18n` — the i18n engine on its own, without the rest of `utils`
 
 ```js

--- a/packages/ranuts/README.zh-CN.md
+++ b/packages/ranuts/README.zh-CN.md
@@ -60,6 +60,7 @@ npm install ranuts@latest --save
 - `ranuts/visual` —— 2D 渲染引擎（Canvas / WebGL / WebGPU，**仅浏览器**）
 - `ranuts/sw` —— 缓存策略 + 预缓存协议的 Service Worker 一侧（**仅 Service Worker**）
 - `ranuts/vnode` —— Snabbdom 风格的虚拟 DOM
+- `ranuts/stream` —— Server-Sent Events 解析，以及对流式模型响应的厂商中立折叠
 - `ranuts/i18n` —— 单独的 i18n 引擎，不牵入 `utils` 的其余部分
 
 ```js

--- a/packages/ranuts/bin/generate-api-docs.ts
+++ b/packages/ranuts/bin/generate-api-docs.ts
@@ -116,6 +116,13 @@ const ENTRIES: Entry[] = [
     blurbCn: 'Snabbdom 风格的虚拟 DOM',
     runtime: 'browser',
   },
+  {
+    subpath: 'ranuts/stream',
+    file: 'src/stream/index.ts',
+    blurb: 'Server-Sent Events parsing and a provider-neutral model-stream fold',
+    blurbCn: 'Server-Sent Events 解析与厂商中立的模型流折叠',
+    runtime: 'browser + node',
+  },
 ];
 
 type Kind = 'function' | 'class' | 'interface' | 'type' | 'enum' | 'const' | 'namespace' | 'other';

--- a/packages/ranuts/docs/API.md
+++ b/packages/ranuts/docs/API.md
@@ -8,16 +8,17 @@ constraints, conventions) read [../CLAUDE.md](../CLAUDE.md) first.
 Import from the **subpath** that owns the symbol, e.g. `import { debounce } from
 'ranuts/utils'`. The root `ranuts` barrel re-exports the utils + visual surface.
 
-**413 exports** across 6 entry points.
+**431 exports** across 7 entry points.
 
 ## Entry points
 
-- [`ranuts/utils`](#ranuts-utils) — Browser and general-purpose utilities · _browser + node_ · 327 exports
+- [`ranuts/utils`](#ranuts-utils) — Browser and general-purpose utilities · _browser + node_ · 330 exports
 - [`ranuts/sw`](#ranuts-sw) — Service Worker caching strategies and the precache protocol · _service worker only_ · 9 exports
 - [`ranuts/node`](#ranuts-node) — Node server utilities (fs / http / ws / middleware) · _node only_ · 26 exports
 - [`ranuts/visual`](#ranuts-visual) — 2D rendering engine (Canvas / WebGL / WebGPU) · _browser only_ · 16 exports
 - [`ranuts/i18n`](#ranuts-i18n) — Framework-agnostic i18n engine (also re-exported from ranuts/utils) · _browser + node_ · 9 exports
 - [`ranuts/vnode`](#ranuts-vnode) — Snabbdom-style virtual DOM · _browser_ · 26 exports
+- [`ranuts/stream`](#ranuts-stream) — Server-Sent Events parsing and a provider-neutral model-stream fold · _browser + node_ · 15 exports
 
 ## `ranuts/utils`
 
@@ -60,6 +61,7 @@ import { /* … */ } from 'ranuts/utils';
 - `cosinePalette(t: number, a: RGB, b: RGB, c: RGB, d: RGB) => RGB` — Inigo Quilez cosine gradient palette: `a + b * cos(2π(c·t + d))`. Each of `a,b,c,d` is an RGB triple; `t` is the position 0..1. Returns an RGB triple.
 - `crc32(data: Uint8Array) => number` — CRC32 checksum (IEEE 802.3 polynomial), the one ZIP stores per entry.
 - `create(tagName: string, options?: ElementCreationOptions) => Chain`
+- `createBottomFollower(options: BottomFollowerOptions) => BottomFollower` — Creates a bottom-follow controller for one scrollport.
 - `createData(params?: Record<string, unknown>) => Record<string, unknown>` — Build the standard envelope that accompanies a report — page URL, referrer,
 - `createDocumentFragment(list: Element[]) => DocumentFragment | undefined` — Create a DocumentFragment
 - `createDoubleTapDetector(options?: DoubleTapDetectorOptions) => DoubleTapDetector` — Double-tap detection over raw `(x, y, time)` samples — pointer-type-agnostic,
@@ -264,6 +266,8 @@ import { /* … */ } from 'ranuts/utils';
 
 - `interface AcceptPortBridgeOptions`
 - `interface BeaconPayload`
+- `interface BottomFollower` — Imperative bottom-follow controller.
+- `interface BottomFollowerOptions` — How to construct a follower.
 - `interface BridgeManagerOptions`
 - `interface BroadcastPayload`
 - `interface CallToPayload`
@@ -557,4 +561,36 @@ import { /* … */ } from 'ranuts/vnode';
 ### Namespaces
 
 - `namespace is` — Type guards — array / string / primitive / VNode
+
+## `ranuts/stream`
+
+Server-Sent Events parsing and a provider-neutral model-stream fold · runtime: **browser + node** · source: `src/stream/index.ts`
+
+```ts
+import { /* … */ } from 'ranuts/stream';
+```
+
+### Functions
+
+- `createStreamAccumulator() => StreamAccumulator` — Creates a fold over one streamed response.
+- `mapEventStream(source: ByteSource, map: (event: ServerSentEvent) => readonly StreamChunk[]) => AsyncGenerator<StreamChunk>` — Maps SSE events onto StreamChunk values using a caller-supplied vendor mapping.
+- `parseEventStream(source: ByteSource) => AsyncGenerator<ServerSentEvent>` — Parses a byte stream as `text/event-stream`.
+
+### Interfaces
+
+- `interface ReasoningBlock` — Model reasoning, when the provider exposes it. Kept separate from TextBlock
+- `interface ServerSentEvent` — One parsed `text/event-stream` event.
+- `interface StreamAccumulator` — Stateful fold over one response's chunks.
+- `interface StreamSnapshot` — Immutable view of everything received so far.
+- `interface TextBlock` — Assistant prose addressed to the user.
+- `interface TokenUsage` — Token counts reported for one response. Every field is optional: providers differ.
+- `interface ToolCallBlock` — One tool invocation requested by the model.
+
+### Types
+
+- `type ByteSource` — Anything `for await` can walk that yields byte chunks — a `fetch` body, or a fake.
+- `type ContentBlock` — One completed unit of assistant output.
+- `type ContentBlockType` — Discriminator for the content a block accumulates.
+- `type FinishReason` — Why the response ended.
+- `type StreamChunk` — One normalized event from a streamed response.
 

--- a/packages/ranuts/package.json
+++ b/packages/ranuts/package.json
@@ -40,6 +40,10 @@
     "./vnode": {
       "types": "./dist/src/vnode/index.d.ts",
       "import": "./dist/src/vnode/index.js"
+    },
+    "./stream": {
+      "types": "./dist/src/stream/index.d.ts",
+      "import": "./dist/src/stream/index.js"
     }
   },
   "repository": {

--- a/packages/ranuts/src/stream/accumulator.ts
+++ b/packages/ranuts/src/stream/accumulator.ts
@@ -1,0 +1,147 @@
+/**
+ * Folds a {@link StreamChunk} sequence into the blocks it describes.
+ *
+ * A renderer wants "the current text", not "every delta since the start", and rebuilding
+ * that by concatenating in the view is where streaming UIs leak: the view ends up owning
+ * ordering, interleaving, and the block-end/delta reconciliation. This owns all three, so
+ * a view reads a snapshot and renders it.
+ */
+import type { ContentBlock, ContentBlockType, FinishReason, StreamChunk, TokenUsage } from './types.ts';
+
+/** Immutable view of everything received so far. */
+export interface StreamSnapshot {
+  /** Completed and in-progress blocks, in `index` order. */
+  readonly blocks: readonly ContentBlock[];
+  /** Latest usage report, once one has arrived. */
+  readonly usage: TokenUsage | undefined;
+  /** Terminal reason, once `finish` has arrived. */
+  readonly finishReason: FinishReason | undefined;
+  /** True once `finish` has arrived. */
+  readonly done: boolean;
+}
+
+/** Stateful fold over one response's chunks. */
+export interface StreamAccumulator {
+  /**
+   * Applies one chunk.
+   *
+   * A delta for an unseen `index` opens its block, because several providers omit
+   * `block-start` entirely. A `block-end` replaces whatever was accumulated at that index:
+   * the assembled block the provider sent is authoritative.
+   *
+   * @param chunk The chunk to fold in.
+   */
+  push(chunk: StreamChunk): void;
+  /** @returns An immutable view of the current state. */
+  snapshot(): StreamSnapshot;
+  /** @returns Every text block concatenated, in index order. */
+  text(): string;
+  /** @returns Every reasoning block concatenated, in index order. */
+  reasoning(): string;
+  /** @returns Completed tool calls, in index order. */
+  toolCalls(): readonly Extract<ContentBlock, { type: 'tool-call' }>[];
+  /** Discards all state so the instance can fold another response. */
+  reset(): void;
+}
+
+/**
+ * Creates an empty block of the given type.
+ *
+ * @param type Block discriminator.
+ * @returns A zero-valued block of that type.
+ */
+function emptyBlock(type: ContentBlockType): ContentBlock {
+  if (type === 'text') return { type: 'text', text: '' };
+  if (type === 'reasoning') return { type: 'reasoning', text: '' };
+  return { type: 'tool-call', id: '', name: '', arguments: '' };
+}
+
+/**
+ * Creates a fold over one streamed response.
+ *
+ * @returns A fresh accumulator with no state.
+ */
+export function createStreamAccumulator(): StreamAccumulator {
+  let blocks = new Map<number, ContentBlock>();
+  let usage: TokenUsage | undefined;
+  let finishReason: FinishReason | undefined;
+
+  const at = (index: number, type: ContentBlockType): ContentBlock => {
+    const existing = blocks.get(index);
+    // A type mismatch means the provider reused an index for a different block; the newer
+    // declaration wins, since the older one can no longer receive deltas.
+    if (existing !== undefined && existing.type === type) return existing;
+    const created = emptyBlock(type);
+    blocks.set(index, created);
+    return created;
+  };
+
+  const ordered = (): ContentBlock[] => [...blocks.entries()].sort(([a], [b]) => a - b).map(([, block]) => block);
+
+  return {
+    push(chunk) {
+      switch (chunk.type) {
+        case 'block-start':
+          at(chunk.index, chunk.blockType);
+          return;
+        case 'text-delta': {
+          const block = at(chunk.index, 'text') as Extract<ContentBlock, { type: 'text' }>;
+          block.text += chunk.text;
+          return;
+        }
+        case 'reasoning-delta': {
+          const block = at(chunk.index, 'reasoning') as Extract<ContentBlock, { type: 'reasoning' }>;
+          block.text += chunk.text;
+          return;
+        }
+        case 'tool-call-delta': {
+          const block = at(chunk.index, 'tool-call') as Extract<ContentBlock, { type: 'tool-call' }>;
+          // The id and name arrive once, usually on the first delta; later deltas repeat
+          // or omit them, and an omission must not blank what is already known.
+          if (chunk.id !== '') block.id = chunk.id;
+          if (chunk.name !== undefined && chunk.name !== '') block.name = chunk.name;
+          block.arguments += chunk.argumentsDelta;
+          return;
+        }
+        case 'block-end':
+          blocks.set(chunk.index, { ...chunk.block });
+          return;
+        case 'usage':
+          usage = chunk.usage;
+          return;
+        case 'finish':
+          finishReason = chunk.reason;
+          return;
+      }
+    },
+
+    snapshot() {
+      return Object.freeze({
+        blocks: Object.freeze(ordered().map((block) => Object.freeze({ ...block }))),
+        usage: usage === undefined ? undefined : Object.freeze({ ...usage }),
+        finishReason,
+        done: finishReason !== undefined,
+      });
+    },
+
+    text() {
+      return ordered().reduce((out, block) => (block.type === 'text' ? out + block.text : out), '');
+    },
+
+    reasoning() {
+      return ordered().reduce((out, block) => (block.type === 'reasoning' ? out + block.text : out), '');
+    },
+
+    toolCalls() {
+      return ordered().filter(
+        (block): block is Extract<ContentBlock, { type: 'tool-call' }> => block.type === 'tool-call',
+      );
+    },
+
+    reset() {
+      blocks = new Map();
+      usage = undefined;
+      finishReason = undefined;
+    },
+  };
+}

--- a/packages/ranuts/src/stream/index.ts
+++ b/packages/ranuts/src/stream/index.ts
@@ -1,0 +1,31 @@
+/**
+ * `ranuts/stream` — streaming model responses, without a vendor.
+ *
+ * Three layers, each usable alone:
+ *
+ * 1. {@link parseEventStream} turns bytes into Server-Sent Events. Transport only.
+ * 2. {@link StreamChunk} is the provider-neutral vocabulary one response streams in.
+ * 3. {@link createStreamAccumulator} folds those chunks into renderable blocks.
+ *
+ * Mapping a vendor's event onto {@link StreamChunk} stays with the caller — that mapping
+ * is the only vendor-specific part, and baking one provider's wire format in here would
+ * make the other two layers unusable for anyone else. {@link mapEventStream} is the seam.
+ *
+ * Runtime: browser and node. No DOM — a stream can be folded in a test or on a server.
+ *
+ * @module ranuts/stream
+ */
+export type {
+  ContentBlock,
+  ContentBlockType,
+  FinishReason,
+  ReasoningBlock,
+  StreamChunk,
+  TextBlock,
+  TokenUsage,
+  ToolCallBlock,
+} from './types.ts';
+export type { ByteSource, ServerSentEvent } from './sse.ts';
+export { mapEventStream, parseEventStream } from './sse.ts';
+export type { StreamAccumulator, StreamSnapshot } from './accumulator.ts';
+export { createStreamAccumulator } from './accumulator.ts';

--- a/packages/ranuts/src/stream/sse.ts
+++ b/packages/ranuts/src/stream/sse.ts
@@ -1,0 +1,153 @@
+/**
+ * Server-Sent Events parsing, to the WHATWG event-stream rules.
+ *
+ * This is the transport half of `ranuts/stream` and knows nothing about models: it turns
+ * bytes into {@link ServerSentEvent} records. Mapping an event's `data` onto
+ * {@link StreamChunk} is the caller's job, because that mapping is vendor-specific while
+ * the framing is not.
+ *
+ * The parts worth not re-deriving: a chunk boundary can fall anywhere, including inside a
+ * multi-byte character and between the two halves of a `\r\n`; `data:` repeats join with
+ * `\n`; exactly one space after the colon is stripped; a line starting with `:` is a
+ * comment (which is how servers keep a connection warm); and a trailing block with no
+ * terminating blank line is still an event.
+ */
+import type { StreamChunk } from './types.ts';
+
+/** One parsed `text/event-stream` event. */
+export interface ServerSentEvent {
+  /** Joined `data:` payload; `\n` between repeats, no trailing newline. */
+  data: string;
+  /** `event:` field, when the server sent one. */
+  event?: string;
+  /** `id:` field, when the server sent one. */
+  id?: string;
+  /** `retry:` field in milliseconds, when the server sent a valid integer. */
+  retry?: number;
+}
+
+/** Anything `for await` can walk that yields byte chunks — a `fetch` body, or a fake. */
+export type ByteSource = AsyncIterable<Uint8Array> | ReadableStream<Uint8Array>;
+
+/**
+ * Normalizes a byte source into an async iterable, so a `ReadableStream` without
+ * `Symbol.asyncIterator` (Safari, and every browser before 2024) walks the same way.
+ *
+ * @param source Byte source to read.
+ * @returns An async iterable over the same chunks.
+ */
+async function* iterate(source: ByteSource): AsyncGenerator<Uint8Array> {
+  // Tested for callability, not presence: a shim can leave the well-known symbol defined
+  // as undefined, and `in` would then send a reader-only stream down the wrong path.
+  const asyncIterator = (source as Partial<AsyncIterable<Uint8Array>>)[Symbol.asyncIterator];
+  if (typeof asyncIterator === 'function') {
+    yield* source as AsyncIterable<Uint8Array>;
+    return;
+  }
+  const reader = (source as ReadableStream<Uint8Array>).getReader();
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) return;
+      if (value !== undefined) yield value;
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+/**
+ * Splits one accumulated event block into a {@link ServerSentEvent}.
+ *
+ * @param block Raw text of one event, without its terminating blank line.
+ * @returns The parsed event, or null when the block held only comments or unknown fields.
+ */
+function parseBlock(block: string): ServerSentEvent | null {
+  const data: string[] = [];
+  let event: string | undefined;
+  let id: string | undefined;
+  let retry: number | undefined;
+
+  for (const line of block.split('\n')) {
+    if (line === '' || line.startsWith(':')) continue;
+    const colon = line.indexOf(':');
+    const field = colon === -1 ? line : line.slice(0, colon);
+    // Exactly one leading space after the colon is part of the framing, not the value.
+    let value = colon === -1 ? '' : line.slice(colon + 1);
+    if (value.startsWith(' ')) value = value.slice(1);
+
+    if (field === 'data') data.push(value);
+    else if (field === 'event') event = value;
+    // A NUL in an id must be ignored per spec; the whole field is dropped rather than sanitized.
+    else if (field === 'id' && !value.includes('\0')) id = value;
+    else if (field === 'retry' && /^\d+$/.test(value)) retry = Number(value);
+  }
+
+  if (data.length === 0 && event === undefined && id === undefined && retry === undefined) return null;
+  const parsed: ServerSentEvent = { data: data.join('\n') };
+  if (event !== undefined) parsed.event = event;
+  if (id !== undefined) parsed.id = id;
+  if (retry !== undefined) parsed.retry = retry;
+  return parsed;
+}
+
+/**
+ * Parses a byte stream as `text/event-stream`.
+ *
+ * Decoding is streaming, so a multi-byte character split across two network chunks is
+ * reassembled rather than replaced. A final block with no terminating blank line is still
+ * yielded, which is what a server that closes the connection mid-event produces.
+ *
+ * @param source Byte source, typically `response.body`.
+ * @returns Each event in arrival order.
+ */
+export async function* parseEventStream(source: ByteSource): AsyncGenerator<ServerSentEvent> {
+  const decoder = new TextDecoder();
+  let buffer = '';
+  let started = false;
+
+  for await (const bytes of iterate(source)) {
+    buffer += decoder.decode(bytes, { stream: true });
+    // Normalize line endings before splitting so a `\r\n` straddling two chunks cannot
+    // leave a stray `\r` at the head of the next line.
+    buffer = buffer.replace(/\r\n?/g, '\n');
+    if (!started) {
+      // A leading BOM belongs to the stream, not to the first field name.
+      if (buffer.startsWith('﻿')) buffer = buffer.slice(1);
+      started = true;
+    }
+
+    let boundary = buffer.indexOf('\n\n');
+    while (boundary !== -1) {
+      const block = buffer.slice(0, boundary);
+      buffer = buffer.slice(boundary + 2);
+      const parsed = parseBlock(block);
+      if (parsed !== null) yield parsed;
+      boundary = buffer.indexOf('\n\n');
+    }
+  }
+
+  buffer += decoder.decode();
+  const tail = parseBlock(buffer.replace(/\r\n?/g, '\n'));
+  if (tail !== null) yield tail;
+}
+
+/**
+ * Maps SSE events onto {@link StreamChunk} values using a caller-supplied vendor mapping.
+ *
+ * The mapping returns an array because one wire event commonly carries several normalized
+ * chunks — a delta plus a usage report, or two concurrent tool calls — and returning an
+ * empty array is how a keep-alive or a sentinel such as `[DONE]` is dropped.
+ *
+ * @param source Byte source, typically `response.body`.
+ * @param map Vendor mapping from one event to zero or more chunks.
+ * @returns Each normalized chunk in arrival order.
+ */
+export async function* mapEventStream(
+  source: ByteSource,
+  map: (event: ServerSentEvent) => readonly StreamChunk[],
+): AsyncGenerator<StreamChunk> {
+  for await (const event of parseEventStream(source)) {
+    yield* map(event);
+  }
+}

--- a/packages/ranuts/src/stream/types.ts
+++ b/packages/ranuts/src/stream/types.ts
@@ -1,0 +1,93 @@
+/**
+ * Provider-neutral vocabulary for one streamed model response.
+ *
+ * Every mainstream chat completion API streams the same four things — assistant text,
+ * separately-billed reasoning text, tool calls, and a token count — but each names them
+ * differently and interleaves them differently. Normalizing to one union at the edge means
+ * a renderer, an accumulator, and a test fixture never learn a vendor's wire format.
+ *
+ * The union is the contract; the shape below is what makes it usable:
+ *
+ * - **`index` correlates interleaved deltas.** Reasoning and text can arrive interleaved,
+ *   and a response can open several tool calls at once. Consumers group by `index` rather
+ *   than assuming a delta belongs to whatever arrived last.
+ * - **`block-end` carries the assembled block.** A consumer that accumulated the deltas
+ *   itself can adopt or verify it; a consumer that only wants finished blocks can ignore
+ *   every delta.
+ * - **Tool arguments stay raw JSON text.** `argumentsDelta` is never parsed mid-stream:
+ *   half a JSON document is not a value, and pretending otherwise is where streaming tool
+ *   calls usually break.
+ * - **`finish` terminates.** `usage` arrives before it, and nothing follows it. A consumer
+ *   can treat `finish` as the point where its state is complete.
+ *
+ * @module ranuts/stream
+ */
+
+/** Discriminator for the content a block accumulates. */
+export type ContentBlockType = 'text' | 'reasoning' | 'tool-call';
+
+/** Assistant prose addressed to the user. */
+export interface TextBlock {
+  type: 'text';
+  text: string;
+}
+
+/**
+ * Model reasoning, when the provider exposes it. Kept separate from {@link TextBlock}
+ * because it is billed, displayed, and retained differently — a UI usually collapses it,
+ * and it is normally dropped from the history sent back on the next request.
+ */
+export interface ReasoningBlock {
+  type: 'reasoning';
+  text: string;
+}
+
+/** One tool invocation requested by the model. */
+export interface ToolCallBlock {
+  type: 'tool-call';
+  /** Provider-assigned call id, echoed back with the result. */
+  id: string;
+  /** Tool name; empty until the provider has sent it. */
+  name: string;
+  /** Raw JSON text of the arguments — deliberately unparsed. */
+  arguments: string;
+}
+
+/** One completed unit of assistant output. */
+export type ContentBlock = TextBlock | ReasoningBlock | ToolCallBlock;
+
+/**
+ * Why the response ended.
+ *
+ * `tool-calls` is not a failure: the model finished its turn by asking for tools, and the
+ * caller is expected to run them and continue. `aborted` means the consumer stopped the
+ * stream, which is why it is distinct from `error`.
+ */
+export type FinishReason = 'stop' | 'length' | 'tool-calls' | 'content-filter' | 'error' | 'aborted';
+
+/** Token counts reported for one response. Every field is optional: providers differ. */
+export interface TokenUsage {
+  inputTokens?: number;
+  outputTokens?: number;
+  /** Reasoning tokens, where the provider bills them separately from output. */
+  reasoningTokens?: number;
+  /** Input tokens served from a provider-side cache, where reported. */
+  cachedInputTokens?: number;
+  totalTokens?: number;
+}
+
+/**
+ * One normalized event from a streamed response.
+ *
+ * `block-start` is optional in practice — several providers begin a block with its first
+ * delta — so consumers must tolerate a delta for an index they have not seen.
+ * {@link createStreamAccumulator} does.
+ */
+export type StreamChunk =
+  | { type: 'block-start'; index: number; blockType: ContentBlockType }
+  | { type: 'text-delta'; index: number; text: string }
+  | { type: 'reasoning-delta'; index: number; text: string }
+  | { type: 'tool-call-delta'; index: number; id: string; name?: string; argumentsDelta: string }
+  | { type: 'block-end'; index: number; block: ContentBlock }
+  | { type: 'usage'; usage: TokenUsage }
+  | { type: 'finish'; reason: FinishReason };

--- a/packages/ranuts/src/utils/index.ts
+++ b/packages/ranuts/src/utils/index.ts
@@ -1,3 +1,4 @@
+import { createBottomFollower } from './scroll';
 import { SyncHook } from './subscribe';
 import {
   Mathjs,
@@ -39,6 +40,7 @@ import {
   slugify,
   csvEscape,
 } from './str';
+import type { BottomFollower, BottomFollowerOptions } from './scroll';
 import type { TransformText, TruncateOptions, TruncatePosition } from './str';
 import { createSpeechRecognizer, isSpeechRecognitionSupported } from './speech';
 import type { SpeechError, SpeechErrorKind, SpeechRecognizer, SpeechRecognizerOptions } from './speech';
@@ -262,6 +264,7 @@ import {
 } from '@/utils/color';
 import type { RGB } from '@/utils/color';
 export {
+  createBottomFollower,
   performanceTime,
   timeFormat,
   timestampToTime,
@@ -592,4 +595,6 @@ export type {
   ComputedPlacement,
   Placement,
   PlacementRect,
+  BottomFollower,
+  BottomFollowerOptions,
 };

--- a/packages/ranuts/src/utils/scroll.ts
+++ b/packages/ranuts/src/utils/scroll.ts
@@ -1,0 +1,219 @@
+/**
+ * Bottom-follow for append-only scrollers — a streaming chat transcript, a log tail, a
+ * terminal pane.
+ *
+ * The requirement sounds trivial and is not: stay pinned to the floor as content arrives,
+ * but the instant the reader scrolls up to read something, stop — and re-pin only when
+ * they come back down themselves. Naive implementations fight the reader, because they
+ * cannot tell their own scroll writes apart from the reader's.
+ *
+ * The mechanism here is an **observed-top ledger**. Every programmatic write records the
+ * `scrollTop` it produced. When a scroll event arrives, a position that matches the ledger
+ * is this module's own write echoing back; a position that deviates is the reader. That
+ * covers wheel, touch, scrollbar drag, keyboard, and `scrollIntoView` from unrelated code
+ * uniformly, without listening for any input device — which matters because no set of
+ * device listeners is ever complete.
+ *
+ * Two cases the ledger has to survive:
+ *
+ * - **Shrink-clamp.** When content shrinks, the browser clamps `scrollTop` to the new
+ *   floor without any reader involvement. Comparing against `min(ledger, floor)` treats
+ *   that clamp as the ledger's own value rather than as a reader scroll, so a clamp
+ *   never changes who owns the scroll position — a reader who had scrolled up stays
+ *   unpinned even when the clamp happens to leave them at the floor, and re-pins on
+ *   their next scroll. Re-pinning on a clamp would take control back without input.
+ * - **Growth while pinned.** Appended content moves the floor away. A scroll event that
+ *   the reader did not cause, while pinned, re-snaps to the new floor.
+ *
+ * Scrolling is always instant. Smooth scrolling animates over a moving target, so during
+ * streaming it visibly lags the content and, worse, its own intermediate positions read as
+ * reader input on the next event.
+ */
+
+/** Distance from the floor still treated as pinned, in CSS pixels. */
+const DEFAULT_THRESHOLD = 24;
+
+/** A row remembered across a prepend, with its offset from the scrollport top. */
+interface CapturedAnchor {
+  row: HTMLElement;
+  top: number;
+}
+
+/** How to construct a follower. */
+export interface BottomFollowerOptions {
+  /** The element that scrolls. */
+  scrollport: HTMLElement;
+  /**
+   * Elements whose size changes should re-follow the floor while pinned — the content
+   * column, and any sticky footer that resizes outside it. Streaming text grows an
+   * existing node rather than appending one, so growth is observed rather than announced.
+   */
+  observe?: readonly HTMLElement[];
+  /** Distance from the floor still counted as pinned. Defaults to 24. */
+  threshold?: number;
+  /**
+   * Called when the pinned state flips, so a caller can show or hide a "jump to latest"
+   * affordance. Never called for a change the caller itself just made synchronously.
+   */
+  onPinnedChange?: (pinned: boolean) => void;
+}
+
+/** Imperative bottom-follow controller. */
+export interface BottomFollower {
+  /** Whether new content is currently being followed. */
+  readonly pinned: boolean;
+  /** Scrolls to the floor and pins, regardless of the current state. */
+  toBottom(): void;
+  /**
+   * Follows the floor only if currently pinned. Safe to call on every content change —
+   * a reader who has scrolled up is left alone.
+   */
+  follow(): void;
+  /**
+   * Remembers a row's current offset from the scrollport top, before content is prepended
+   * above it. Capture a row that is actually on screen, so the restore keeps what the
+   * reader is looking at exactly where it was.
+   *
+   * @param row The row to keep still.
+   */
+  captureAnchor(row: HTMLElement): void;
+  /**
+   * Restores the captured row to its captured offset, then forgets it.
+   *
+   * @param resolve Re-resolves the row after the prepend, for callers that replace nodes
+   *   rather than reuse them. Omit when the captured element is still in the document.
+   * @returns Whether an anchor was restored.
+   */
+  restoreAnchor(resolve?: () => HTMLElement | null): boolean;
+  /** Discards any captured anchor without restoring it. */
+  releaseAnchor(): void;
+  /** Removes the scroll listener and disconnects the resize observer. */
+  destroy(): void;
+}
+
+/**
+ * Greatest scrollable offset — the position at which the scroller is at its floor.
+ *
+ * @param el The scrollport.
+ * @returns The floor offset, never negative.
+ */
+function floorOf(el: HTMLElement): number {
+  return Math.max(0, el.scrollHeight - el.clientHeight);
+}
+
+/**
+ * Offset of a row from the top of the scrollport, in scrollport coordinates.
+ *
+ * Measured through `getBoundingClientRect` on both, so the result is independent of page
+ * scroll, transforms on ancestors, and whichever element actually owns the overflow.
+ *
+ * @param row The row to measure.
+ * @param scrollport The scrolling element.
+ * @returns Pixels between the scrollport's top edge and the row's top edge.
+ */
+function offsetWithin(row: HTMLElement, scrollport: HTMLElement): number {
+  return row.getBoundingClientRect().top - scrollport.getBoundingClientRect().top;
+}
+
+/**
+ * Creates a bottom-follow controller for one scrollport.
+ *
+ * The controller starts pinned, which is what an append-only view wants on first paint and
+ * after a reload. To restore a remembered position instead, set `scrollTop` before or
+ * after construction and the first scroll event will settle the pinned state from the
+ * geometry.
+ *
+ * @param options Scrollport, elements to observe, and threshold.
+ * @returns The controller; call `destroy` to release its listeners.
+ */
+export function createBottomFollower(options: BottomFollowerOptions): BottomFollower {
+  const { scrollport, observe = [], threshold = DEFAULT_THRESHOLD, onPinnedChange } = options;
+
+  let pinned = true;
+  /** Last position this module wrote, or was told about, on the main thread. */
+  let observedTop = scrollport.scrollTop;
+  let anchor: CapturedAnchor | null = null;
+  let destroyed = false;
+
+  const setPinned = (next: boolean): void => {
+    if (next === pinned) return;
+    pinned = next;
+    onPinnedChange?.(next);
+  };
+
+  const writeTop = (top: number): void => {
+    scrollport.scrollTop = top;
+    // Read back rather than trusting the assignment: the browser clamps to the current
+    // floor, and a ledger holding an unreachable value would read as a reader scroll.
+    observedTop = scrollport.scrollTop;
+  };
+
+  const toBottom = (): void => {
+    anchor = null;
+    writeTop(scrollport.scrollHeight);
+    setPinned(true);
+  };
+
+  const onScroll = (): void => {
+    const floor = floorOf(scrollport);
+    // A shrink-clamp lands exactly on the floor, and a delayed delivery of this module's
+    // own write lands on the ledger; both must keep the current ownership.
+    const movedByReader = Math.abs(scrollport.scrollTop - Math.min(observedTop, floor)) > 0.5;
+    if (!movedByReader) {
+      // Not the reader: if we are following, the floor moved under us — catch up.
+      if (pinned) toBottom();
+      else observedTop = scrollport.scrollTop;
+      return;
+    }
+    observedTop = scrollport.scrollTop;
+    setPinned(floor - scrollport.scrollTop <= threshold);
+  };
+
+  scrollport.addEventListener('scroll', onScroll, { passive: true });
+
+  let observer: ResizeObserver | null = null;
+  if (observe.length > 0 && typeof ResizeObserver !== 'undefined') {
+    observer = new ResizeObserver(() => {
+      if (pinned && !destroyed) writeTop(scrollport.scrollHeight);
+    });
+    for (const element of observe) observer.observe(element);
+  }
+
+  return {
+    get pinned() {
+      return pinned;
+    },
+
+    toBottom,
+
+    follow() {
+      if (pinned) writeTop(scrollport.scrollHeight);
+    },
+
+    captureAnchor(row) {
+      anchor = { row, top: offsetWithin(row, scrollport) };
+    },
+
+    restoreAnchor(resolve) {
+      if (anchor === null) return false;
+      // `resolve` returning null means the row did not survive the prepend, which is
+      // not the same as no resolver being supplied — `??` would conflate the two.
+      const row = resolve === undefined ? anchor.row : resolve();
+      const { top } = anchor;
+      anchor = null;
+      if (row === null || !scrollport.contains(row)) return false;
+      writeTop(scrollport.scrollTop + offsetWithin(row, scrollport) - top);
+      return true;
+    },
+
+    releaseAnchor() {
+      anchor = null;
+    },
+
+    destroy() {
+      destroyed = true;
+      scrollport.removeEventListener('scroll', onScroll);
+      observer?.disconnect();
+    },
+  };
+}

--- a/packages/ranuts/test/scroll.test.ts
+++ b/packages/ranuts/test/scroll.test.ts
@@ -1,0 +1,317 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createBottomFollower } from '@/utils/scroll.ts';
+
+/**
+ * A scrollport with real clamping geometry.
+ *
+ * jsdom cannot host these tests: it has no layout engine, so `scrollHeight` is always 0
+ * and every position is simultaneously the floor. The behaviour under test is entirely
+ * about geometry — clamping on shrink, the distance to the floor, a row's offset — so the
+ * fake models exactly that and fires scroll events on demand, which also removes the
+ * async delivery a browser would impose.
+ */
+class FakeScroller {
+  scrollHeight = 1000;
+  clientHeight = 400;
+  top = 0;
+  private position = 0;
+  private listeners = new Set<() => void>();
+
+  get scrollTop(): number {
+    return this.position;
+  }
+
+  /** Clamps like a browser: a write past the floor lands on the floor. */
+  set scrollTop(next: number) {
+    this.position = Math.max(0, Math.min(next, Math.max(0, this.scrollHeight - this.clientHeight)));
+  }
+
+  get floor(): number {
+    return Math.max(0, this.scrollHeight - this.clientHeight);
+  }
+
+  addEventListener(_type: string, handler: () => void): void {
+    this.listeners.add(handler);
+  }
+
+  removeEventListener(_type: string, handler: () => void): void {
+    this.listeners.delete(handler);
+  }
+
+  getBoundingClientRect(): { top: number } {
+    return { top: this.top };
+  }
+
+  contains(): boolean {
+    return true;
+  }
+
+  /** Fires the scroll event a browser would deliver after a position change. */
+  emitScroll(): void {
+    for (const handler of this.listeners) handler();
+  }
+
+  /** Reader input: moves the position and delivers the event. */
+  readerScrollTo(next: number): void {
+    this.scrollTop = next;
+    this.emitScroll();
+  }
+
+  /** Content growth: extends the flow and delivers the event the browser would. */
+  grow(by: number): void {
+    this.scrollHeight += by;
+    this.emitScroll();
+  }
+
+  /** Content shrink: the browser clamps the position, then delivers a scroll event. */
+  shrink(by: number): void {
+    this.scrollHeight = Math.max(this.clientHeight, this.scrollHeight - by);
+    this.scrollTop = this.position;
+    this.emitScroll();
+  }
+
+  get listenerCount(): number {
+    return this.listeners.size;
+  }
+}
+
+/**
+ * A row at a position in the scroller's flow.
+ *
+ * Its viewport offset is derived the way a browser derives it — flow position minus the
+ * current scroll offset — so an assertion about where the row ends up on screen is a real
+ * assertion rather than a restatement of the arithmetic under test.
+ *
+ * @param scroller The scrollport the row lives in.
+ * @param flowTop Distance from the top of the scrollable content.
+ * @returns A minimal element exposing `getBoundingClientRect`, plus its mutable flow position.
+ */
+function fakeRow(
+  scroller: FakeScroller,
+  flowTop: number,
+): { getBoundingClientRect: () => { top: number }; flowTop: number } {
+  const row = {
+    flowTop,
+    getBoundingClientRect: (): { top: number } => ({ top: row.flowTop - scroller.scrollTop + scroller.top }),
+  };
+  return row;
+}
+
+/**
+ * Builds a follower over a fake scrollport.
+ *
+ * @param options Threshold and pinned-change spy.
+ * @returns The scroller, the follower, and the spy.
+ */
+function setup(options: { threshold?: number } = {}) {
+  const scroller = new FakeScroller();
+  const onPinnedChange = vi.fn();
+  const follower = createBottomFollower({
+    scrollport: scroller as unknown as HTMLElement,
+    onPinnedChange,
+    ...options,
+  });
+  return { scroller, follower, onPinnedChange };
+}
+
+describe('createBottomFollower', () => {
+  it('starts pinned, which is what a reload of an append-only view wants', () => {
+    const { follower } = setup();
+    expect(follower.pinned).toBe(true);
+  });
+
+  it('follows the floor while pinned', () => {
+    const { scroller, follower } = setup();
+    scroller.scrollHeight = 2000;
+    follower.follow();
+    expect(scroller.scrollTop).toBe(scroller.floor);
+  });
+
+  it('unpins when the reader scrolls up, and reports the flip once', () => {
+    const { scroller, follower, onPinnedChange } = setup();
+    follower.toBottom();
+    onPinnedChange.mockClear();
+    scroller.readerScrollTo(100);
+    expect(follower.pinned).toBe(false);
+    expect(onPinnedChange).toHaveBeenCalledExactlyOnceWith(false);
+  });
+
+  it('leaves the reader alone once unpinned, however much content arrives', () => {
+    const { scroller, follower } = setup();
+    scroller.readerScrollTo(100);
+    follower.follow();
+    scroller.grow(5000);
+    follower.follow();
+    expect(scroller.scrollTop).toBe(100);
+    expect(follower.pinned).toBe(false);
+  });
+
+  it('re-pins when the reader scrolls back within the threshold', () => {
+    const { scroller, follower } = setup({ threshold: 24 });
+    scroller.readerScrollTo(100);
+    scroller.readerScrollTo(scroller.floor - 10);
+    expect(follower.pinned).toBe(true);
+  });
+
+  it('stays unpinned just outside the threshold', () => {
+    const { scroller, follower } = setup({ threshold: 24 });
+    scroller.readerScrollTo(100);
+    scroller.readerScrollTo(scroller.floor - 25);
+    expect(follower.pinned).toBe(false);
+  });
+
+  it('catches up to the new floor when growth moves it while pinned', () => {
+    const { scroller, follower } = setup();
+    follower.toBottom();
+    scroller.grow(600);
+    expect(scroller.scrollTop).toBe(scroller.floor);
+    expect(follower.pinned).toBe(true);
+  });
+
+  it('does not read a shrink-clamp as reader input', () => {
+    const { scroller, follower, onPinnedChange } = setup();
+    follower.toBottom();
+    onPinnedChange.mockClear();
+    scroller.shrink(400);
+    expect(follower.pinned).toBe(true);
+    expect(onPinnedChange).not.toHaveBeenCalled();
+  });
+
+  it('lets a shrink-clamp leave the reader at the floor without taking control back', () => {
+    const { scroller, follower } = setup();
+    scroller.readerScrollTo(500);
+    expect(follower.pinned).toBe(false);
+    // Content shrinks below the reader's position, so the browser clamps them onto the
+    // floor. Only reader input transfers ownership, so this does not re-pin.
+    scroller.shrink(500);
+    expect(scroller.scrollTop).toBe(scroller.floor);
+    expect(follower.pinned).toBe(false);
+    // Their next scroll settles it from the geometry, as it would anywhere else.
+    scroller.readerScrollTo(0);
+    scroller.readerScrollTo(scroller.floor);
+    expect(follower.pinned).toBe(true);
+  });
+
+  it('does not unpin when its own write is delivered late', () => {
+    const { scroller, follower, onPinnedChange } = setup();
+    follower.toBottom();
+    onPinnedChange.mockClear();
+    // The browser delivers the event for the write above only now; the position matches
+    // the ledger, so ownership must not change.
+    scroller.emitScroll();
+    expect(follower.pinned).toBe(true);
+    expect(onPinnedChange).not.toHaveBeenCalled();
+  });
+
+  it('re-pins from anywhere on toBottom', () => {
+    const { scroller, follower } = setup();
+    scroller.readerScrollTo(50);
+    follower.toBottom();
+    expect(follower.pinned).toBe(true);
+    expect(scroller.scrollTop).toBe(scroller.floor);
+  });
+
+  it('keeps an anchored row still across a prepend', () => {
+    const { scroller, follower } = setup();
+    scroller.readerScrollTo(300);
+    const row = fakeRow(scroller, 420);
+    expect(row.getBoundingClientRect().top).toBe(120);
+    follower.captureAnchor(row as unknown as HTMLElement);
+
+    // A prepend inserts 250px above the row: the flow grows and the row moves down in it.
+    scroller.scrollHeight += 250;
+    row.flowTop += 250;
+    // Without a restore the reader would be looking at different content.
+    expect(row.getBoundingClientRect().top).toBe(370);
+
+    expect(follower.restoreAnchor()).toBe(true);
+    expect(scroller.scrollTop).toBe(550);
+    // The row is back exactly where the reader had it.
+    expect(row.getBoundingClientRect().top).toBe(120);
+  });
+
+  it('reports no restore when nothing was captured', () => {
+    const { follower } = setup();
+    expect(follower.restoreAnchor()).toBe(false);
+  });
+
+  it('forgets a released anchor', () => {
+    const { scroller, follower } = setup();
+    follower.captureAnchor(fakeRow(scroller, 10) as unknown as HTMLElement);
+    follower.releaseAnchor();
+    expect(follower.restoreAnchor()).toBe(false);
+  });
+
+  it('drops an anchor whose row the prepend replaced', () => {
+    const { scroller, follower } = setup();
+    scroller.readerScrollTo(300);
+    follower.captureAnchor(fakeRow(scroller, 420) as unknown as HTMLElement);
+    // A resolver reporting null means the row is gone — distinct from supplying none.
+    expect(follower.restoreAnchor(() => null)).toBe(false);
+    expect(scroller.scrollTop).toBe(300);
+  });
+
+  it('drops the anchor when toBottom overrides it', () => {
+    const { scroller, follower } = setup();
+    follower.captureAnchor(fakeRow(scroller, 10) as unknown as HTMLElement);
+    follower.toBottom();
+    expect(follower.restoreAnchor()).toBe(false);
+  });
+
+  it('releases its listener on destroy', () => {
+    const { scroller, follower } = setup();
+    expect(scroller.listenerCount).toBe(1);
+    follower.destroy();
+    expect(scroller.listenerCount).toBe(0);
+  });
+});
+
+describe('createBottomFollower resize observation', () => {
+  let observed: Element[] = [];
+  let trigger: (() => void) | null = null;
+
+  beforeEach(() => {
+    observed = [];
+    trigger = null;
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        constructor(callback: () => void) {
+          trigger = callback;
+        }
+        observe(element: Element): void {
+          observed.push(element);
+        }
+        disconnect(): void {
+          trigger = null;
+        }
+      },
+    );
+    return () => vi.unstubAllGlobals();
+  });
+
+  it('follows growth that appends no node, such as streaming text', () => {
+    const scroller = new FakeScroller();
+    const column = {} as HTMLElement;
+    const follower = createBottomFollower({ scrollport: scroller as unknown as HTMLElement, observe: [column] });
+    expect(observed).toEqual([column]);
+
+    scroller.scrollHeight = 3000;
+    trigger?.();
+    expect(scroller.scrollTop).toBe(scroller.floor);
+    follower.destroy();
+  });
+
+  it('does not write while the reader is scrolled up', () => {
+    const scroller = new FakeScroller();
+    const follower = createBottomFollower({
+      scrollport: scroller as unknown as HTMLElement,
+      observe: [{} as HTMLElement],
+    });
+    scroller.readerScrollTo(120);
+    scroller.scrollHeight = 3000;
+    trigger?.();
+    expect(scroller.scrollTop).toBe(120);
+    follower.destroy();
+  });
+});

--- a/packages/ranuts/test/stream.test.ts
+++ b/packages/ranuts/test/stream.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it } from 'vitest';
+import { createStreamAccumulator, mapEventStream, parseEventStream } from '@/stream/index.ts';
+import type { ServerSentEvent, StreamChunk } from '@/stream/index.ts';
+
+/**
+ * Feeds text as bytes in caller-chosen slices, so a test can put a chunk boundary
+ * anywhere — including inside a multi-byte character or between `\r` and `\n`.
+ *
+ * @param parts Byte-level slices delivered in order.
+ * @returns An async iterable over those slices.
+ */
+async function* bytes(...parts: (string | Uint8Array)[]): AsyncGenerator<Uint8Array> {
+  const encoder = new TextEncoder();
+  for (const part of parts) yield typeof part === 'string' ? encoder.encode(part) : part;
+}
+
+/**
+ * A `ReadableStream` with no `Symbol.asyncIterator`, matching browsers that never shipped it.
+ *
+ * @param parts Chunks to emit.
+ * @returns A reader-only stream over those chunks.
+ */
+function readableWithoutAsyncIterator(...parts: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const part of parts) controller.enqueue(encoder.encode(part));
+      controller.close();
+    },
+  });
+  Object.defineProperty(stream, Symbol.asyncIterator, { value: undefined });
+  return stream;
+}
+
+/**
+ * Drains an async iterable.
+ *
+ * @param source Iterable to drain.
+ * @returns Everything it yielded.
+ */
+async function collect<T>(source: AsyncIterable<T>): Promise<T[]> {
+  const out: T[] = [];
+  for await (const item of source) out.push(item);
+  return out;
+}
+
+describe('parseEventStream', () => {
+  it('yields one event per blank-line-terminated block', async () => {
+    const events = await collect(parseEventStream(bytes('data: a\n\ndata: b\n\n')));
+    expect(events).toEqual([{ data: 'a' }, { data: 'b' }]);
+  });
+
+  it('joins repeated data fields with a newline', async () => {
+    const events = await collect(parseEventStream(bytes('data: first\ndata: second\n\n')));
+    expect(events).toEqual([{ data: 'first\nsecond' }]);
+  });
+
+  it('strips exactly one space after the colon', async () => {
+    const events = await collect(parseEventStream(bytes('data:  two spaces\n\n')));
+    expect(events[0].data).toBe(' two spaces');
+  });
+
+  it('reads a field with no colon as an empty value', async () => {
+    const events = await collect(parseEventStream(bytes('data\n\n')));
+    expect(events).toEqual([{ data: '' }]);
+  });
+
+  it('ignores comment lines, which is how servers keep a connection warm', async () => {
+    const events = await collect(parseEventStream(bytes(': keep-alive\n\ndata: real\n\n')));
+    expect(events).toEqual([{ data: 'real' }]);
+  });
+
+  it('carries event, id and retry fields', async () => {
+    const events = await collect(parseEventStream(bytes('event: ping\nid: 7\nretry: 3000\ndata: x\n\n')));
+    expect(events).toEqual([{ data: 'x', event: 'ping', id: '7', retry: 3000 }]);
+  });
+
+  it('drops a non-integer retry and an id containing NUL', async () => {
+    const events = await collect(parseEventStream(bytes('retry: soon\nid: a\0b\ndata: x\n\n')));
+    expect(events).toEqual([{ data: 'x' }]);
+  });
+
+  it('reassembles an event split across chunk boundaries', async () => {
+    const events = await collect(parseEventStream(bytes('da', 'ta: sp', 'lit\n', '\n')));
+    expect(events).toEqual([{ data: 'split' }]);
+  });
+
+  it('reassembles a multi-byte character split across chunks', async () => {
+    const encoded = new TextEncoder().encode('data: 中文\n\n');
+    const events = await collect(parseEventStream(bytes(encoded.slice(0, 8), encoded.slice(8))));
+    expect(events).toEqual([{ data: '中文' }]);
+  });
+
+  it('handles CRLF, including a pair split across chunks', async () => {
+    const events = await collect(parseEventStream(bytes('data: a\r', '\n\r\ndata: b\r\n\r\n')));
+    expect(events).toEqual([{ data: 'a' }, { data: 'b' }]);
+  });
+
+  it('strips a leading BOM rather than corrupting the first field name', async () => {
+    const events = await collect(parseEventStream(bytes('﻿data: a\n\n')));
+    expect(events).toEqual([{ data: 'a' }]);
+  });
+
+  it('yields a trailing block that the server never terminated', async () => {
+    const events = await collect(parseEventStream(bytes('data: a\n\ndata: cut')));
+    expect(events).toEqual([{ data: 'a' }, { data: 'cut' }]);
+  });
+
+  it('yields nothing for a stream of only comments and blank lines', async () => {
+    expect(await collect(parseEventStream(bytes(': a\n\n: b\n\n')))).toEqual([]);
+  });
+
+  it('reads a ReadableStream that has no async iterator', async () => {
+    const events = await collect(parseEventStream(readableWithoutAsyncIterator('data: a\n\n', 'data: b\n\n')));
+    expect(events).toEqual([{ data: 'a' }, { data: 'b' }]);
+  });
+});
+
+describe('mapEventStream', () => {
+  it('drops events the mapping rejects and flattens the ones it expands', async () => {
+    const map = (event: ServerSentEvent): StreamChunk[] => {
+      if (event.data === '[DONE]') return [];
+      return [
+        { type: 'text-delta', index: 0, text: event.data },
+        { type: 'usage', usage: { outputTokens: event.data.length } },
+      ];
+    };
+    const chunks = await collect(mapEventStream(bytes('data: hi\n\ndata: [DONE]\n\n'), map));
+    expect(chunks).toEqual([
+      { type: 'text-delta', index: 0, text: 'hi' },
+      { type: 'usage', usage: { outputTokens: 2 } },
+    ]);
+  });
+});
+
+describe('createStreamAccumulator', () => {
+  it('opens a block from its first delta when the provider sends no block-start', () => {
+    const acc = createStreamAccumulator();
+    acc.push({ type: 'text-delta', index: 0, text: 'he' });
+    acc.push({ type: 'text-delta', index: 0, text: 'llo' });
+    expect(acc.text()).toBe('hello');
+  });
+
+  it('keeps interleaved reasoning and text apart, ordered by index', () => {
+    const acc = createStreamAccumulator();
+    acc.push({ type: 'block-start', index: 0, blockType: 'reasoning' });
+    acc.push({ type: 'block-start', index: 1, blockType: 'text' });
+    acc.push({ type: 'reasoning-delta', index: 0, text: 'think ' });
+    acc.push({ type: 'text-delta', index: 1, text: 'answer ' });
+    acc.push({ type: 'reasoning-delta', index: 0, text: 'more' });
+    acc.push({ type: 'text-delta', index: 1, text: 'here' });
+    expect(acc.reasoning()).toBe('think more');
+    expect(acc.text()).toBe('answer here');
+    expect(acc.snapshot().blocks.map((b) => b.type)).toEqual(['reasoning', 'text']);
+  });
+
+  it('sorts blocks numerically, not lexically', () => {
+    const acc = createStreamAccumulator();
+    acc.push({ type: 'text-delta', index: 10, text: 'ten' });
+    acc.push({ type: 'text-delta', index: 2, text: 'two ' });
+    expect(acc.text()).toBe('two ten');
+  });
+
+  it('lets block-end replace what the deltas accumulated', () => {
+    const acc = createStreamAccumulator();
+    acc.push({ type: 'text-delta', index: 0, text: 'partial' });
+    acc.push({ type: 'block-end', index: 0, block: { type: 'text', text: 'authoritative' } });
+    expect(acc.text()).toBe('authoritative');
+  });
+
+  it('keeps a tool call id and name that later deltas omit', () => {
+    const acc = createStreamAccumulator();
+    acc.push({ type: 'tool-call-delta', index: 0, id: 'call_1', name: 'search', argumentsDelta: '{"q"' });
+    acc.push({ type: 'tool-call-delta', index: 0, id: '', argumentsDelta: ':"ran"}' });
+    expect(acc.toolCalls()).toEqual([{ type: 'tool-call', id: 'call_1', name: 'search', arguments: '{"q":"ran"}' }]);
+  });
+
+  it('accumulates concurrent tool calls independently', () => {
+    const acc = createStreamAccumulator();
+    acc.push({ type: 'tool-call-delta', index: 0, id: 'a', name: 'one', argumentsDelta: '{"x"' });
+    acc.push({ type: 'tool-call-delta', index: 1, id: 'b', name: 'two', argumentsDelta: '{"y"' });
+    acc.push({ type: 'tool-call-delta', index: 0, id: 'a', argumentsDelta: ':1}' });
+    acc.push({ type: 'tool-call-delta', index: 1, id: 'b', argumentsDelta: ':2}' });
+    expect(acc.toolCalls().map((c) => c.arguments)).toEqual(['{"x":1}', '{"y":2}']);
+  });
+
+  it('never parses tool arguments, so half a JSON document stays text', () => {
+    const acc = createStreamAccumulator();
+    acc.push({ type: 'tool-call-delta', index: 0, id: 'a', name: 'f', argumentsDelta: '{"a": [1,' });
+    expect(acc.toolCalls()[0].arguments).toBe('{"a": [1,');
+  });
+
+  it('replaces a block when the provider reuses an index for another type', () => {
+    const acc = createStreamAccumulator();
+    acc.push({ type: 'text-delta', index: 0, text: 'text' });
+    acc.push({ type: 'reasoning-delta', index: 0, text: 'reasoning' });
+    expect(acc.text()).toBe('');
+    expect(acc.reasoning()).toBe('reasoning');
+  });
+
+  it('records usage and finish, and reports done only after finish', () => {
+    const acc = createStreamAccumulator();
+    expect(acc.snapshot().done).toBe(false);
+    acc.push({ type: 'usage', usage: { inputTokens: 10, outputTokens: 4 } });
+    expect(acc.snapshot().done).toBe(false);
+    acc.push({ type: 'finish', reason: 'tool-calls' });
+    const snapshot = acc.snapshot();
+    expect(snapshot.usage).toEqual({ inputTokens: 10, outputTokens: 4 });
+    expect(snapshot.finishReason).toBe('tool-calls');
+    expect(snapshot.done).toBe(true);
+  });
+
+  it('returns a snapshot that later pushes cannot mutate', () => {
+    const acc = createStreamAccumulator();
+    acc.push({ type: 'text-delta', index: 0, text: 'first' });
+    const snapshot = acc.snapshot();
+    acc.push({ type: 'text-delta', index: 0, text: ' second' });
+    expect(snapshot.blocks[0]).toEqual({ type: 'text', text: 'first' });
+    expect(acc.text()).toBe('first second');
+  });
+
+  it('clears every field on reset', () => {
+    const acc = createStreamAccumulator();
+    acc.push({ type: 'text-delta', index: 0, text: 'x' });
+    acc.push({ type: 'usage', usage: { outputTokens: 1 } });
+    acc.push({ type: 'finish', reason: 'stop' });
+    acc.reset();
+    expect(acc.snapshot()).toEqual({ blocks: [], usage: undefined, finishReason: undefined, done: false });
+  });
+});

--- a/packages/ranuts/vite.config.ts
+++ b/packages/ranuts/vite.config.ts
@@ -121,6 +121,9 @@ export const es: BuildOptions = {
       // Its own entry because it runs in a ServiceWorkerGlobalScope — no window, no document.
       sw: resolve(__dirname, 'src/sw/index.ts'),
       vnode: resolve(__dirname, 'src/vnode/index.ts'),
+      // Its own entry so a consumer folding a model stream on a server or in a test
+      // does not pull the DOM-oriented `ranuts/utils` barrel along with it.
+      stream: resolve(__dirname, 'src/stream/index.ts'),
     },
     fileName: (_: string, name: string): string => {
       if (name === 'index') {


### PR DESCRIPTION
> Stacked on #378 — base retargets to `main` once that merges. Review the [last two commits](https://github.com/chaxus/ran/pull/379/commits).

Two primitives for rendering a streamed conversation, both pure logic, both in `ranuts` so they stay testable and framework-free. `ranui` already has the hardest piece — `r-markdown` in `mode="streaming"` closes half-streamed `**bold`, backticks, links and `$$` math through `remend`. What was missing is the layer around it.

Both are distilled from a production agent harness, and both are things you only get right after getting them wrong.

---

## 1 · `ranuts/stream`

Every mainstream chat completion API streams the same four things — assistant text, separately-billed reasoning text, tool calls, a token count — but each names and interleaves them differently. Without a normalizing layer that difference reaches the view, and the view ends up owning ordering, interleaving and delta reconciliation.

Three layers, each usable alone. The split is the point: **only the middle one is vendor-specific, and it is the one this does not ship.**

| Layer | What |
| --- | --- |
| `parseEventStream(source)` | bytes → `ServerSentEvent`. Transport only, no model concepts. |
| `StreamChunk` | the vocabulary. You write the mapping; `mapEventStream` is the seam. |
| `createStreamAccumulator()` | folds chunks into blocks — `snapshot()` / `text()` / `reasoning()` / `toolCalls()`. |

### What the vocabulary encodes

```ts
type StreamChunk =
  | { type: 'block-start';      index: number; blockType: ContentBlockType }
  | { type: 'text-delta';       index: number; text: string }
  | { type: 'reasoning-delta';  index: number; text: string }
  | { type: 'tool-call-delta';  index: number; id: string; name?: string; argumentsDelta: string }
  | { type: 'block-end';        index: number; block: ContentBlock }
  | { type: 'usage';            usage: TokenUsage }
  | { type: 'finish';           reason: FinishReason }
```

- **`index` correlates interleaved deltas.** Reasoning and text arrive interleaved and several tool calls open at once — arrival order is not grouping.
- **`block-end` carries the assembled block, and wins.** A consumer that only wants finished blocks can ignore every delta.
- **Tool arguments stay raw JSON text.** Half a JSON document is not a value; parsing `argumentsDelta` mid-stream is where streaming tool calls usually break.
- **`block-start` is optional.** Several providers open a block with its first delta, so the accumulator opens one on demand rather than dropping it.
- **`finish` terminates.** `usage` precedes it, nothing follows it.

The SSE parser handles what actually bites: a chunk boundary anywhere — including inside a multi-byte character and between the halves of a CRLF — repeated `data:` joined with a newline, exactly one space stripped after the colon, `:` comment keep-alives, a leading BOM, and a trailing block the server never terminated.

Runtime-neutral: no DOM, so a stream folds in a test or on a server. Its own build entry, so folding a response never drags the DOM-oriented `ranuts/utils` barrel in.

**26 tests.** Writing them found a real defect: the reader-stream fallback tested `Symbol.asyncIterator in source`, which is true when a shim leaves the symbol defined as `undefined`. Now tests for callability.

---

## 2 · `createBottomFollower`

Stay pinned to the floor as content arrives; stop the instant the reader scrolls up; re-pin only when they come back down themselves. Sounds trivial, is not — an implementation that cannot tell its own scroll writes from the reader's will fight them.

The mechanism is an **observed-top ledger**: every programmatic write records the `scrollTop` it produced. A scroll event whose position deviates from the ledger is the reader; one that matches is our own write echoing back. That covers wheel, touch, scrollbar drag, keyboard, and a stray `scrollIntoView` from unrelated code at once — **without listening for any input device**, which matters because no list of device listeners is ever complete.

The cases it has to survive, each a bug in the naive version:

| Case | Handling |
| --- | --- |
| **Shrink-clamp** | The browser clamps `scrollTop` with no reader involvement. Comparing against `min(ledger, floor)` treats it as the ledger's own value. Ownership is deliberately **preserved** — a reader who had scrolled up stays unpinned even when the clamp leaves them at the floor, and re-pins on their next scroll. Re-pinning on a clamp takes control back with no input from them. |
| **Growth while pinned** | A scroll event the reader did not cause, while pinned, re-snaps to the new floor. |
| **Growth appending no node** | Streaming text grows an *existing* node — observed via `ResizeObserver`, not announced. |
| **Prepend (load older)** | `captureAnchor(row)` remembers a visible row's offset; `restoreAnchor()` puts it back, so the reader keeps looking at what they were looking at. |

Scrolling is always instant. Smooth scrolling animates toward a target that moves during streaming, and its own intermediate positions read as reader input on the next event.

**On refresh:** the follower starts pinned, which is what an append-only view wants on first paint and after a reload. To restore a remembered position instead, set `scrollTop` and the first scroll event settles the state from the geometry.

**19 tests, against a fake scrollport rather than jsdom** — jsdom has no layout engine, so `scrollHeight` is always 0 and every position is simultaneously the floor; it cannot express any of the behaviour above. The fake clamps like a browser and derives a row's viewport offset from its flow position, so the anchor assertions are real rather than a restatement of the arithmetic under test.

Writing them found a real defect: `restoreAnchor` used `resolve?.() ?? anchor.row`, so a resolver reporting the row as gone silently fell back to the stale element.

---

## Docs

`CLAUDE.md` gets the new entry in the import map and the layout tree, plus two sections covering the non-obvious rules (group by `index`, never parse arguments mid-stream, `block-end` wins; call `follow()` freely, `observe` for node-less growth, anchor before a prepend, why a clamp does not re-pin). READMEs updated in both languages, and `docs/API.md` and its two docs-site copies regenerated — the freshness gate from #378 covers the new entry automatically.

## Verification

`pnpm run lint` (oxlint + prettier + builds + tsc), `pnpm run test` (848 in ranuts, up 45), `verify:docs`, `verify:design`, `publint` — all pass. The built `dist/src/stream/index.js` was smoke-tested through the published `exports` path.