### PR TITLE
fix(ranuts): remove the quadratic backtracking from four exported paths

### DIFF
--- a/packages/ranuts/src/utils/canvas.ts
+++ b/packages/ranuts/src/utils/canvas.ts
@@ -82,6 +82,28 @@ export const roundRectByArc = (ctx: CanvasRenderingContext2D, ...[x, y, w, h, r]
   ctx.closePath();
 };
 
+const LINEAR_GRADIENT = 'linear-gradient(';
+
+/**
+ * The text between `linear-gradient(` and the closing parenthesis.
+ *
+ * Located by index rather than by `/linear-gradient\((.+)\)/`, whose `.+` re-scans to the end
+ * of the string from every starting position when no closing parenthesis follows — quadratic in
+ * the length of a value this library accepts from its caller.
+ *
+ * @param {string} background a CSS `linear-gradient(...)` value
+ * @return {string} the argument list, still unsplit
+ * @throws {TypeError} when `background` is not a `linear-gradient(...)` value
+ */
+const gradientBody = (background: string): string => {
+  const open = background.indexOf(LINEAR_GRADIENT);
+  const close = background.lastIndexOf(')');
+  if (open === -1 || close <= open + LINEAR_GRADIENT.length) {
+    throw new TypeError('getLinearGradient: background must be a linear-gradient(...) value');
+  }
+  return background.slice(open + LINEAR_GRADIENT.length, close);
+};
+
 /**
  * @description: Translate a CSS `linear-gradient(...)` string into a Canvas CanvasGradient.
  *
@@ -96,6 +118,7 @@ export const roundRectByArc = (ctx: CanvasRenderingContext2D, ...[x, y, w, h, r]
  * @param {number} h rectangle height
  * @param {string} background a string such as `linear-gradient(90deg, red, blue)`
  * @return {CanvasGradient} assignable straight to fillStyle / strokeStyle
+ * @throws {TypeError} when `background` is not a `linear-gradient(...)` value
  */
 export const getLinearGradient = (
   ctx: CanvasRenderingContext2D,
@@ -105,7 +128,7 @@ export const getLinearGradient = (
   h: number,
   background: string,
 ): CanvasGradient => {
-  const context = (/linear-gradient\((.+)\)/.exec(background) as Array<string>)[1]
+  const context = gradientBody(background)
     .split(',') // split on commas
     .map((text: string) => text.trim()); // trim each part
   let deg = context.shift() as string;

--- a/packages/ranuts/src/utils/localePath.ts
+++ b/packages/ranuts/src/utils/localePath.ts
@@ -42,9 +42,25 @@ export interface LocalePath {
   alternates: (pathname: string) => Array<{ code: string; href: string }>;
 }
 
+/**
+ * Drop the run of `/` at the end of `value`.
+ *
+ * A loop rather than `/\/+$/`, which re-scans to the end from every position when the string
+ * does not end in a slash — quadratic in the length of a base this library accepts from its
+ * caller, and the miss is the common case.
+ *
+ * @param {string} value
+ * @return {string}
+ */
+const trimTrailingSlash = (value: string): string => {
+  let end = value.length;
+  while (end > 0 && value[end - 1] === '/') end--;
+  return value.slice(0, end);
+};
+
 /** Normalise the base: drop the trailing slash, add a leading one; an empty base stays empty */
 const normalizeBase = (base: string): string => {
-  const trimmed = base.trim().replace(/\/+$/, '');
+  const trimmed = trimTrailingSlash(base.trim());
   if (!trimmed) return '';
   return trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
 };

--- a/packages/ranuts/src/utils/str.ts
+++ b/packages/ranuts/src/utils/str.ts
@@ -1139,6 +1139,24 @@ export const fenceCode = (body: string, lang: string = ''): string => {
 };
 
 /**
+ * Drop the runs of `-` at both ends of `value`.
+ *
+ * A loop rather than `/^-+|-+$/g`, whose `-+` re-scans to the end from every position it can
+ * start at. The collapse step before it leaves no two adjacent dashes, so the scan stays short
+ * here, but that is a property of one caller rather than of the expression.
+ *
+ * @param {string} value
+ * @return {string}
+ */
+const trimDashes = (value: string): string => {
+  let start = 0;
+  let end = value.length;
+  while (start < end && value[start] === '-') start++;
+  while (end > start && value[end - 1] === '-') end--;
+  return value.slice(start, end);
+};
+
+/**
  * @description: Reduce text to a lowercase `a-z0-9-` slug, safe as a filename on every
  * filesystem and as a URL segment.
  *
@@ -1151,12 +1169,7 @@ export const fenceCode = (body: string, lang: string = ''): string => {
  * @return {string} the slug, or `''` when nothing survived
  */
 export const slugify = (text: string, maxLength: number = 60): string =>
-  text
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .slice(0, maxLength)
-    .replace(/-+$/g, '');
+  trimDashes(trimDashes(text.toLowerCase().replace(/[^a-z0-9]+/g, '-')).slice(0, maxLength));
 
 /**
  * @description: Escape one CSV field: doubles any quote and wraps the value when it contains

--- a/packages/ranuts/src/utils/time.ts
+++ b/packages/ranuts/src/utils/time.ts
@@ -8,8 +8,12 @@ const toDate = (value?: DateInput): Date => (value === undefined || value === nu
 /**
  * Format tokens, longest first so `YYYY` is matched before `YY` and `MM` before `M`.
  * Case is significant: `MM` is the month, `mm` the minute; `HH` is 24-hour, `hh` 12-hour.
+ *
+ * A `[...]` literal cannot contain `[`. Admitting one costs an unclosed `[` a scan to the end of
+ * the pattern from every position it appears at, which is quadratic in a pattern this library
+ * accepts from its caller; excluding it makes each attempt fail at the next character.
  */
-const TOKEN = /YYYY|YY|MM|M|DD|D|HH|H|hh|h|mm|m|ss|s|SSS|A|a|\[([^\]]*)]/g;
+const TOKEN = /YYYY|YY|MM|M|DD|D|HH|H|hh|h|mm|m|ss|s|SSS|A|a|\[([^[\]]*)]/g;
 
 /**
  * @description: Format a date with a token pattern. Accepts a timestamp, a date string, a

--- a/packages/ranuts/test/canvas.test.ts
+++ b/packages/ranuts/test/canvas.test.ts
@@ -89,6 +89,22 @@ describe('utils/canvas', () => {
     expect(ctx.createLinearGradient).toHaveBeenCalledWith(...expected);
   });
 
+  it('rejects a value that is not a linear-gradient', () => {
+    const ctx = createContextMock();
+    expect(() => getLinearGradient(ctx, 0, 0, 100, 50, 'red')).toThrow(TypeError);
+    // An empty argument list has nothing to make stops from
+    expect(() => getLinearGradient(ctx, 0, 0, 100, 50, 'linear-gradient()')).toThrow(TypeError);
+  });
+
+  it('rejects an unterminated value without rescanning it', () => {
+    // The argument list is located by index. Finding the closing parenthesis with `.+` instead
+    // costs a scan to the end of the string from every position it could start at, which took
+    // ~10s at this length. The assertion is the result; the runner's timeout is the guard.
+    const ctx = createContextMock();
+    const unterminated = `linear-gradient(${'linear-gradient(a'.repeat(20_000)}`;
+    expect(() => getLinearGradient(ctx, 0, 0, 100, 50, unterminated)).toThrow(TypeError);
+  });
+
   it.each([0, 30, 60, 120, 160, 200, 240, 300, 330])('creates linear gradients for %sdeg', (degree) => {
     const ctx = createContextMock();
     getLinearGradient(ctx, 0, 0, 100, 50, `linear-gradient(${degree}deg, red, blue)`);

--- a/packages/ranuts/test/utils/format.test.ts
+++ b/packages/ranuts/test/utils/format.test.ts
@@ -38,6 +38,18 @@ describe('formatDate', () => {
     expect(formatDate(SAMPLE, '[MM]MM')).toBe('MM07');
   });
 
+  it('ends a literal at the next bracket of either kind', () => {
+    // A literal cannot contain '[', so the opening one here is not a literal and stands as text.
+    expect(formatDate(SAMPLE, '[x[y]')).toBe('[xy');
+  });
+
+  it('leaves unclosed brackets alone without rescanning them', () => {
+    // Admitting '[' inside a literal costs each unclosed one a scan to the end of the pattern,
+    // which took ~14s at this length. The assertion is the result; the timeout is the guard.
+    const pattern = '['.repeat(100_000);
+    expect(formatDate(SAMPLE, pattern)).toBe(pattern);
+  });
+
   it('accepts a timestamp, a string or nothing', () => {
     expect(formatDate(SAMPLE.getTime(), 'YYYY')).toBe('2026');
     expect(formatDate('2026-07-25T00:00:00.000Z', 'YYYY')).toBe('2026');

--- a/packages/ranuts/test/utils/locale-path.test.ts
+++ b/packages/ranuts/test/utils/locale-path.test.ts
@@ -72,6 +72,14 @@ describe('createLocalePath — sub-directory deployment', () => {
 
   it('normalizes the base by dropping the trailing slash', () => {
     expect(paths.base).toBe('/weread');
+    expect(createLocalePath({ locales: LOCALES, base: '/weread///' }).base).toBe('/weread');
+  });
+
+  it('leaves a base that does not end in a slash alone, however many it contains', () => {
+    // The miss is the common case, and `/\/+$/` answers it by rescanning from every slash —
+    // ~14s at this length. The assertion is the result; the runner's timeout is the guard.
+    const base = `${'/'.repeat(100_000)}x`;
+    expect(createLocalePath({ locales: LOCALES, base }).base).toBe(base);
   });
 
   it('prepends the base to every generated link', () => {


### PR DESCRIPTION
Closes the four open CodeQL `js/polynomial-redos` alerts (79–82). Each regex is applied to a parameter of an exported function, so for a published library the input is the caller's.

## What was measured

Every alert was reproduced before it was touched — n doubles, time quadruples:

| | expression | 16k chars, before | after | at 200k chars |
| --- | --- | --- | --- | --- |
| `getLinearGradient` | `/linear-gradient\((.+)\)/` | **6467ms** | 0.2ms | 2.0ms |
| `createLocalePath` | `/\/+$/` | 360ms | 0.0ms | 0.0ms |
| `formatDate` | `/\[([^\]]*)]/g` | 360ms | 0.1ms | 1.6ms |
| `slugify` | `/^-+\|-+$/g` | not reachable | — | — |

In all three reachable cases the *miss* is what costs: the expression re-scans to the end of the string from every position it could start at.

`slugify` is the fourth alert and is a false positive. Its preceding `.replace(/[^a-z0-9]+/g, '-')` collapses every run of non-alphanumerics into a single dash, so `-+` can never match more than one character. CodeQL does not carry that invariant across the step. It is a loop now because the loop is plainer than the expression, not because the sample was slow.

## What changed

- **`canvas.ts`** — the argument list is located with `indexOf`/`lastIndexOf`. A value that is not a gradient now throws a `TypeError` naming what was expected, where it used to subscript a null match.
- **`localePath.ts`** — trailing slashes are trimmed by a loop.
- **`time.ts`** — the regex stays; a `[...]` literal now ends at the next bracket of either kind, so an unclosed `[` fails at the following character instead of scanning ahead. A literal can no longer contain `[`, which is documented at the pattern and covered by a test.
- **`str.ts`** — `slugify` trims dashes by a loop.

## Regression guards

The three reachable cases each get a test that asserts the **result** for an input long enough that the old expression exceeded the runner's 5s timeout. Verified by reverting the sources: three time out, plus the `time.ts` literal-semantics test fails — the four fixes are each pinned. No timing threshold is asserted, so a slow runner cannot make these flake.

## Checks

`vitest` 920 passed (69 files) · `tsc --noEmit` · `pnpm run lint` (oxlint + prettier + verify-packages + verify-md-links + workspace tsc) · `pnpm run verify:docs` — all clean. `packages/ranuts` is byte-identical between this base and the tree the checks ran on.