### PR TITLE
feat(ranui)!: the builder creates SVG in the SVG namespace

### DIFF
--- a/packages/ranui/CHANGELOG.md
+++ b/packages/ranui/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to `ranui` will be documented in this file.
 
 ### Added
 
+- **The builder creates SVG elements in the SVG namespace.** `View('svg')` and
+  every other SVG-only tag (`path`, `circle`, `g`, …) now go through
+  `createElementNS`, and `Svg()` is exported for the tags SVG shares with HTML
+  (`a`, `script`, `style`, `title`), where inferring would break the commoner
+  HTML case. Previously every tag went through `document.createElement`, which
+  returns an `HTMLUnknownElement` for `svg`: the browser does not render it as
+  SVG, and — because HTML lowercases attribute names — `viewBox` arrived as
+  `viewbox`, which SVG reads case-sensitively and therefore ignores. An icon
+  built with the builder was blank, with markup that read correctly in a
+  serialized page. Found from the outside: a static-site generator rendering the
+  same page under node and under jsdom produced different bytes, and the
+  difference was a flattened `viewBox`.
+
 - **One floating-panel controller behind `r-select` and `r-popover` (`FloatingController`, exported)** — portalling, positioning (flip/shift/alignment), following the anchor on scroll and resize, the enter/exit animation and the open/closed state machine were written twice, once per component, and had begun to drift: `r-select`'s reposition listeners carried a comment saying they mirrored `r-popover`'s, which is what keeping a shared thing in step by hand looks like just before it stops working. Both now drive the same controller and pass in only what they alone know — `r-select` the panel width it copies from its trigger (and the rendered width a consumer may have widened past it with `::part(dropdown)`), `r-popover` which light-DOM child is the trigger and where its arrow must end up. Exported from the barrel so a third floating component gets this rather than a third copy.
 - **`open` on `r-select` and `r-popover`** — a reflected attribute, and _the_ state, the way `<details open>` and `<dialog open>` are. Nothing infers it from the panel's `style.display` any more, which trails the state by the length of the exit animation. `show()` / `hide()` / `toggle()` are the methods; `:host([open])` becomes stylable, `el.open = true` a supported way to drive either component, and an attribute assertion replaces polling a style in tests.
 - **`show` / `after-show` / `hide` / `after-hide` on both components** — the first of each pair announces the intent as the transition starts, the second fires once the panel has arrived and any animation has finished. Neither component previously offered any way to know a panel had opened. Declared with the standard `@fires` JSDoc tag, which the API doc generator now reads — events dispatched from the shared controller are invisible to a scan of the component file, so both would otherwise have been documented as having no events at all.

--- a/packages/ranui/docs/BUILDER.md
+++ b/packages/ranui/docs/BUILDER.md
@@ -49,6 +49,28 @@ const submit = View('r-button') // any tag, incl. custom elements
   .build();
 ```
 
+### SVG
+
+Tags that only exist in SVG (`svg`, `path`, `circle`, `g`, …) are created in the
+SVG namespace automatically — `document.createElement('svg')` would return an
+`HTMLUnknownElement` that the browser does not render as SVG, and whose
+`viewBox` would be flattened to `viewbox` and then ignored.
+
+```ts
+const icon = View('svg')
+  .attrs({ viewBox: '0 0 16 16', 'aria-hidden': 'true' })
+  .children(View('circle').attrs({ cx: '8', cy: '8', r: '6.25' }).build())
+  .build();
+```
+
+The tags SVG shares with HTML — `a`, `script`, `style`, `title` — stay HTML,
+since guessing would break the far commoner case. Use `Svg()` when one of those
+is meant as SVG:
+
+```ts
+Svg('a').attr('href', '#').children(View('path').attr('d', 'M1 1').build()).build();
+```
+
 Factories: `View(tag)`, `Div`, `Span`, `Slot`, `ButtonBuilder`, `InputBuilder`,
 `Label`, `Ul`, `Li`, `Section`, `Article`, `Nav`, `Header`, `Footer`, `Main`,
 `Style`, `DeclarativeShadow`. For anything else use `View('tag')`.

--- a/packages/ranui/package.json
+++ b/packages/ranui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ranui",
-  "version": "0.5.0-alpha.5",
+  "version": "0.5.0-alpha.6",
   "description": "A framework-agnostic Web Components UI library built on native custom elements, with TypeScript types, light/dark theming, SSR and PWA support.",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/packages/ranui/test/unit/builder.core.browser.test.ts
+++ b/packages/ranui/test/unit/builder.core.browser.test.ts
@@ -900,3 +900,56 @@ describe('Composition — Show/Switch containing For/Index', () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// SVG namespace
+// ---------------------------------------------------------------------------
+
+describe('SVG elements', () => {
+  /**
+   * `document.createElement('svg')` returns an `HTMLUnknownElement`. Nothing
+   * about that is loud: the element exists, children append to it, and a
+   * serialized page looks right at a glance. What breaks is invisible from the
+   * JS side -- the browser does not render it as SVG, and HTML lowercases
+   * attribute names, so `viewBox` arrives as `viewbox` and SVG (which reads it
+   * case-sensitively) ignores it. The icon comes out blank.
+   *
+   * Found from the outside: a static-site generator rendering the same page in
+   * node and in jsdom produced different bytes, and the difference was that one
+   * `viewBox` had been flattened.
+   */
+  it('creates SVG-only tags in the SVG namespace', () => {
+    const svg = new ElementBuilder('svg').build();
+    const path = new ElementBuilder('path').build();
+    expect(svg.namespaceURI).toBe('http://www.w3.org/2000/svg');
+    expect(path.namespaceURI).toBe('http://www.w3.org/2000/svg');
+  });
+
+  it('keeps camelCase attribute names, which SVG reads case-sensitively', () => {
+    const svg = new ElementBuilder('svg').attrs({ viewBox: '0 0 16 16' }).build();
+    expect(svg.getAttribute('viewBox')).toBe('0 0 16 16');
+    expect(svg.outerHTML).toContain('viewBox="0 0 16 16"');
+  });
+
+  it('leaves the tags SVG shares with HTML as HTML', () => {
+    // Guessing here would break the far commoner case: `View('a')` is a link.
+    for (const tag of ['a', 'script', 'style', 'title']) {
+      expect(new ElementBuilder(tag).build().namespaceURI).toBe('http://www.w3.org/1999/xhtml');
+    }
+  });
+
+  it('takes an explicit namespace for those shared tags', () => {
+    const link = new ElementBuilder('a', 'http://www.w3.org/2000/svg').build();
+    expect(link.namespaceURI).toBe('http://www.w3.org/2000/svg');
+  });
+
+  it('nests as SVG, so an icon built through the builder actually renders', () => {
+    const icon = new ElementBuilder('svg')
+      .attrs({ viewBox: '0 0 16 16', 'aria-hidden': 'true' })
+      .children(new ElementBuilder('circle').attrs({ cx: '8', cy: '8', r: '6.25' }).build())
+      .build();
+    expect(icon.outerHTML).toBe(
+      '<svg viewBox="0 0 16 16" aria-hidden="true"><circle cx="8" cy="8" r="6.25"></circle></svg>',
+    );
+  });
+});

--- a/packages/ranui/utils/builder/core.ts
+++ b/packages/ranui/utils/builder/core.ts
@@ -408,11 +408,77 @@ const appendChildren = (parent: Node, items: Child[]): void => {
   });
 };
 
+export const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
+
+/**
+ * Tags that exist only in SVG, so a builder can create them correctly without
+ * being told which namespace they belong to.
+ *
+ * Deliberately excludes the tags SVG shares with HTML -- `a`, `script`,
+ * `style`, `title` -- since guessing wrong there would silently produce the
+ * wrong kind of element for the far more common HTML case. Reach for `Svg()`
+ * when one of those is meant as SVG.
+ */
+const SVG_ONLY_TAGS = new Set([
+  'svg',
+  'circle',
+  'clipPath',
+  'defs',
+  'desc',
+  'ellipse',
+  'feBlend',
+  'feColorMatrix',
+  'feComposite',
+  'feDropShadow',
+  'feFlood',
+  'feGaussianBlur',
+  'feMerge',
+  'feMergeNode',
+  'feOffset',
+  'filter',
+  'foreignObject',
+  'g',
+  'image',
+  'line',
+  'linearGradient',
+  'marker',
+  'mask',
+  'path',
+  'pattern',
+  'polygon',
+  'polyline',
+  'radialGradient',
+  'rect',
+  'stop',
+  'switch',
+  'symbol',
+  'text',
+  'textPath',
+  'tspan',
+  'use',
+]);
+
 export class ElementBuilder<T extends HTMLElement = HTMLElement> {
   private el: T;
 
-  constructor(tag: string) {
-    this.el = (isSSR ? new HTMLElementMock(tag) : document.createElement(tag)) as unknown as T;
+  /**
+   * @param tag element name
+   * @param namespace element namespace; inferred for SVG-only tags, and forced
+   * by `Svg()` for the tags SVG shares with HTML.
+   *
+   * The namespace matters more than it looks. `document.createElement('svg')`
+   * yields an `HTMLUnknownElement`: the browser does not render it as SVG, and
+   * -- because HTML lowercases attribute names -- `viewBox` lands as `viewbox`,
+   * which SVG reads case-sensitively and therefore ignores. An icon built that
+   * way is invisible, with markup that looks right in a serialized page.
+   */
+  constructor(tag: string, namespace?: string) {
+    const ns = namespace ?? (SVG_ONLY_TAGS.has(tag) ? SVG_NAMESPACE : undefined);
+    this.el = (isSSR
+      ? new HTMLElementMock(tag)
+      : ns
+        ? document.createElementNS(ns, tag)
+        : document.createElement(tag)) as unknown as T;
   }
 
   id(value: string): this {

--- a/packages/ranui/utils/builder/factory.ts
+++ b/packages/ranui/utils/builder/factory.ts
@@ -1,7 +1,23 @@
-import { ElementBuilder } from './core';
+import { ElementBuilder, SVG_NAMESPACE } from './core';
 
 export const View = <T extends HTMLElement = HTMLElement>(tag: string): ElementBuilder<T> => new ElementBuilder<T>(tag);
 export const Div = (): ElementBuilder<HTMLDivElement> => View<HTMLDivElement>('div');
+
+/**
+ * An element in the SVG namespace.
+ *
+ * `View()` already infers it for tags that only exist in SVG (`path`, `circle`,
+ * `g`, …), so this is for the ones SVG shares with HTML -- `a`, `script`,
+ * `style`, `title` -- where guessing would break the commoner HTML case.
+ *
+ * ```ts
+ * View('svg').attrs({ viewBox: '0 0 16 16' }).children(
+ *   Svg('a').attr('href', '#').children(View('path').attr('d', 'M1 1').build()).build(),
+ * );
+ * ```
+ */
+export const Svg = <T extends HTMLElement = HTMLElement>(tag: string): ElementBuilder<T> =>
+  new ElementBuilder<T>(tag, SVG_NAMESPACE);
 export const Span = (): ElementBuilder<HTMLSpanElement> => View<HTMLSpanElement>('span');
 export const Slot = (): ElementBuilder<HTMLSlotElement> => View<HTMLSlotElement>('slot');
 export const ButtonBuilder = (): ElementBuilder<HTMLButtonElement> => View<HTMLButtonElement>('button');

--- a/packages/ranui/utils/builder/index.ts
+++ b/packages/ranui/utils/builder/index.ts
@@ -33,10 +33,12 @@ export {
   Match,
   ElementBuilder,
   ShadowBuilder,
+  SVG_NAMESPACE,
 } from './core';
 export {
   View,
   Div,
+  Svg,
   Span,
   Slot,
   ButtonBuilder,


### PR DESCRIPTION
`ElementBuilder` sent every tag through `document.createElement`, which returns
an `HTMLUnknownElement` for `svg`. Nothing about that is loud: the element
exists, children append to it, and a serialized page reads correctly. What
breaks is invisible from the JS side -- the browser does not render it as SVG,
and HTML lowercases attribute names, so `viewBox` arrives as `viewbox`, which
SVG reads case-sensitively and ignores. An icon built with the builder came out
blank. Anyone reaching for `View('svg')` hit this.

SVG-only tags (`svg`, `path`, `circle`, `g`, `linearGradient`, …) are now
created with `createElementNS`, inferred from the tag. The tags SVG shares with
HTML -- `a`, `script`, `style`, `title` -- deliberately stay HTML, because
guessing there would silently produce the wrong element for the far commoner
case; `Svg()` is exported for when one of those is meant as SVG, and
`ElementBuilder` takes an explicit namespace as its second argument.

Found from the outside rather than by a failing test: a static-site generator
that renders the same page under node and under jsdom produced different bytes
for it, and the difference was a `viewBox` flattened on the jsdom side. Under
node the builder falls back to ranui's own DOM mock, which does not lowercase,
so only one of the two environments was wrong -- and the one that ships was the
right one, which is why nothing had gone visibly wrong yet.

Reverse-checked: with every tag back on `createElement`, four of the five new
cases fail. They assert the rendered attribute and the namespace, not that an
element was returned -- the old code returned one of those too.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
