### PR TITLE
feat(ranui): unsafeHtml() on the builder, and mock/DOM parity for content

### DIFF
--- a/packages/ranui/CHANGELOG.md
+++ b/packages/ranui/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to `ranui` will be documented in this file.
 
 ### Added
 
+- **`unsafeHtml()` on the builder.** `text()` escapes, so until now a builder
+  tree could not contain content that already is HTML — rendered markdown, a
+  fragment assembled elsewhere, a translated string carrying its own emphasis
+  (`Local-first · <b>open source</b>`). There was no way to express it at all,
+  which is why a static-site generator with markdown in it had to concatenate
+  strings instead of using this API. Named for the difference: everything handed
+  to it is parsed as markup, so sanitize anything from outside the program
+  first. It replaces the element's content, and the last of `text()` /
+  `unsafeHtml()` to run wins, as in the DOM.
+
 - **The builder creates SVG elements in the SVG namespace.** `View('svg')` and
   every other SVG-only tag (`path`, `circle`, `g`, …) now go through
   `createElementNS`, and `Svg()` is exported for the tags SVG shares with HTML
@@ -54,6 +64,14 @@ All notable changes to `ranui` will be documented in this file.
 - **Default (secondary) `r-button` hover no longer flips to the accent color** — it darkens the border (gray 400 → 500) and keeps primary text, per the Geist state ladder; the default ripple is now a translucent gray (`--ran-gray-alpha-400`) instead of primary blue.
 
 ### Fixed
+
+- **The SSR mock's `textContent` and `innerHTML` replace each other, as they do
+  in a browser.** The mock kept both and let serialization prefer the text, so
+  `el.textContent = 'a'; el.innerHTML = '<b/>'` rendered `a` under node and
+  `<b/>` in a browser; reading `innerHTML` back after setting `textContent`
+  returned the markup that had been replaced. Only visible when the same
+  template is rendered in both environments — which is exactly what a
+  static-site generator under vitest does.
 
 - **A run of clicks on `r-select`'s trigger no longer wedges the menu** — hover the trigger, click (opens), click again without moving (closes), click again: the panel flashed open, shut itself, and from there the menu was stuck. The trigger ran _both_ transitions on every click, close then open, and which one survived depended on which of two 300ms animation timers happened to be in flight, because each read `style.display` to decide whether it had anything to do. Inside that window `display` answers about the frame rather than the intent. The trigger now toggles `open`, which is the state.
 - **`aria-expanded` can no longer drift from the panel** — measured mid-sequence in the same bug, the combobox announced itself expanded while its panel was `display: none`. One code path now writes the display, the transit class, the reposition listeners and `aria-expanded`, so the four cannot disagree.

--- a/packages/ranui/docs/BUILDER.md
+++ b/packages/ranui/docs/BUILDER.md
@@ -49,6 +49,20 @@ const submit = View('r-button') // any tag, incl. custom elements
   .build();
 ```
 
+### Markup that is already HTML
+
+`text()` escapes; `unsafeHtml()` does not. It is the only way to put content
+that _is_ HTML into a builder tree — rendered markdown, a fragment assembled
+elsewhere, a translated string carrying its own emphasis.
+
+```ts
+View('p').unsafeHtml('Local-first · <b>open source</b>').build();
+```
+
+Everything handed to it is parsed as markup, so sanitize anything that came from
+outside the program first. Like `textContent`, it replaces whatever content the
+element had, and the last of `text()` / `unsafeHtml()` to run wins.
+
 ### SVG
 
 Tags that only exist in SVG (`svg`, `path`, `circle`, `g`, …) are created in the

--- a/packages/ranui/package.json
+++ b/packages/ranui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ranui",
-  "version": "0.5.0-alpha.6",
+  "version": "0.5.0-alpha.7",
   "description": "A framework-agnostic Web Components UI library built on native custom elements, with TypeScript types, light/dark theming, SSR and PWA support.",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/packages/ranui/test/unit/builder.core.browser.test.ts
+++ b/packages/ranui/test/unit/builder.core.browser.test.ts
@@ -953,3 +953,38 @@ describe('SVG elements', () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// unsafeHtml
+// ---------------------------------------------------------------------------
+
+describe('unsafeHtml', () => {
+  /**
+   * The counterpart to `text()`. Without it a builder cannot express content
+   * that already is HTML -- rendered markdown, a fragment assembled elsewhere, a
+   * translated string carrying its own emphasis -- which is why a static-site
+   * generator with markdown in it had to concatenate strings instead.
+   */
+  it('inserts markup as markup, where text() would escape it', () => {
+    const withText = new ElementBuilder('div').text('<b>hi</b>').build();
+    const withHtml = new ElementBuilder('div').unsafeHtml('<b>hi</b>').build();
+
+    expect(withText.textContent).toBe('<b>hi</b>');
+    expect(withText.innerHTML).toBe('&lt;b&gt;hi&lt;/b&gt;');
+    expect(withHtml.innerHTML).toBe('<b>hi</b>');
+    expect(withHtml.querySelector('b')).not.toBeNull();
+  });
+
+  it('replaces whatever content the element had', () => {
+    const el = new ElementBuilder('div')
+      .children(new ElementBuilder('span').text('first').build())
+      .unsafeHtml('<i>second</i>')
+      .build();
+    expect(el.innerHTML).toBe('<i>second</i>');
+  });
+
+  it('is last-write-wins against text(), the way the DOM is', () => {
+    expect(new ElementBuilder('div').text('a').unsafeHtml('<b>c</b>').build().innerHTML).toBe('<b>c</b>');
+    expect(new ElementBuilder('div').unsafeHtml('<b>c</b>').text('a').build().innerHTML).toBe('a');
+  });
+});

--- a/packages/ranui/test/unit/ssr.test.ts
+++ b/packages/ranui/test/unit/ssr.test.ts
@@ -4,6 +4,7 @@
 import { describe, it, expect } from 'vitest';
 import { Button } from '@/components/button/index';
 import { renderToString } from '@/utils/ssr';
+import { HTMLElementMock } from '@/utils/builder';
 
 describe('SSR Rendering', () => {
   it('should render r-button with DSD template', () => {
@@ -24,5 +25,49 @@ describe('SSR Rendering', () => {
     // Check for internal structure (class name from Builder)
     expect(html).toContain('class="ran-btn"');
     expect(html).toContain('class="ran-btn-content"');
+  });
+});
+
+/**
+ * The SSR mock and a real DOM have to agree, because the same template can be
+ * rendered in both -- a static-site generator runs under node for the build and
+ * under jsdom in its own tests, and a difference between the two shows up as
+ * "the committed page and a fresh render disagree" with no obvious cause.
+ */
+describe('mock/DOM parity for element content', () => {
+  it('lets textContent and innerHTML replace each other, last write winning', () => {
+    const textThenHtml = new HTMLElementMock('div');
+    textThenHtml.textContent = 'plain';
+    textThenHtml.innerHTML = '<b>markup</b>';
+    expect(textThenHtml.serialize()).toBe('<div><b>markup</b></div>');
+
+    const htmlThenText = new HTMLElementMock('div');
+    htmlThenText.innerHTML = '<b>markup</b>';
+    htmlThenText.textContent = 'plain';
+    expect(htmlThenText.serialize()).toBe('<div>plain</div>');
+  });
+
+  it('reads innerHTML back as whichever was written last', () => {
+    // In a browser, `el.innerHTML = '<b/>'; el.textContent = 'a'` leaves
+    // `el.innerHTML` as `a` -- the text replaced the markup, and reading it back
+    // says so. A mock that kept returning the old markup would let code branch
+    // one way here and the other way in a browser.
+    const el = new HTMLElementMock('div');
+    el.innerHTML = '<b>markup</b>';
+    el.textContent = 'a';
+    expect(el.innerHTML).toBe('a');
+
+    el.innerHTML = '<i>again</i>';
+    expect(el.innerHTML).toBe('<i>again</i>');
+  });
+
+  it('escapes text and leaves markup alone, matching the browser', () => {
+    const text = new HTMLElementMock('div');
+    text.textContent = '<b>hi</b>';
+    expect(text.serialize()).toBe('<div>&lt;b&gt;hi&lt;/b&gt;</div>');
+
+    const html = new HTMLElementMock('div');
+    html.innerHTML = '<b>hi</b>';
+    expect(html.serialize()).toBe('<div><b>hi</b></div>');
   });
 });

--- a/packages/ranui/utils/builder/core.ts
+++ b/packages/ranui/utils/builder/core.ts
@@ -656,6 +656,30 @@ export class ElementBuilder<T extends HTMLElement = HTMLElement> {
     return this;
   }
 
+  /**
+   * Set the element's content from a string of markup, without escaping it.
+   *
+   * The counterpart to `text()`, and named for the difference: `text()` escapes,
+   * this does not. Everything handed here is parsed as HTML, so anything that
+   * came from outside the program must be sanitized before it arrives.
+   *
+   * It exists because some content simply *is* HTML, and a builder without this
+   * cannot express it at all: markdown rendered for a page, a fragment assembled
+   * somewhere else, a translated string that carries its own emphasis
+   * (`Local-first · <b>open source</b>`). That gap is why a static-site
+   * generator with markdown in it could not be written against this API and had
+   * to concatenate strings instead.
+   *
+   * Like `textContent`, this replaces whatever content the element had --
+   * including anything set by `text()` or `children()` before it.
+   */
+  unsafeHtml(value: string | Getter<string>): this {
+    this.bind(value, (v) => {
+      this.el.innerHTML = v;
+    });
+    return this;
+  }
+
   ref(holder: Ref<T>): this {
     holder.current = this.el;
     return this;

--- a/packages/ranui/utils/builder/mocks.ts
+++ b/packages/ranui/utils/builder/mocks.ts
@@ -40,7 +40,24 @@ export class HTMLElementMock {
   public inlineStyles: Map<string, string> = new Map<string, string>();
   public childrenList: (HTMLElementMock | string | DocumentFragmentMock)[] = [];
   public shadowRoot: ShadowRootMock | null = null;
-  public textContent: string | null = null;
+  private _textContent: string | null = null;
+
+  /**
+   * Setting either `textContent` or `innerHTML` replaces the element's content
+   * in a real DOM, so the last one written wins. This mock used to keep both
+   * and let `serialize()` prefer the text, which meant
+   * `el.textContent = 'a'; el.innerHTML = '<b/>'` rendered `a` here and `<b/>`
+   * in a browser -- the kind of difference that only surfaces once the same
+   * template is rendered in both, which is exactly what a static-site generator
+   * under vitest does.
+   */
+  get textContent(): string | null {
+    return this._textContent;
+  }
+
+  set textContent(value: string | null) {
+    this._textContent = value;
+  }
   public content?: DocumentFragmentMock;
   private eventListeners: Map<string, Set<EventListenerOrEventListenerObject>> = new Map();
 
@@ -73,11 +90,16 @@ export class HTMLElementMock {
   private _innerHTML: string = '';
 
   get innerHTML(): string {
+    // Reading it back reflects whichever was written last, as a browser does:
+    // after `el.textContent = 'a'`, `el.innerHTML` is `a`, not the markup that
+    // was there before.
+    if (this._textContent !== null) return escapeHtml(this._textContent);
     return this._innerHTML;
   }
 
   set innerHTML(value: string) {
     this._innerHTML = value;
+    this._textContent = null;
     if (this.tagName === 'template' && this.content) {
       this.content.childrenList = [value];
     }


### PR DESCRIPTION
Two things, one gap: the builder could not express content that is already HTML.

`text()` escapes, and there was nothing that does not. So rendered markdown, a
fragment assembled elsewhere, or a translated string carrying its own emphasis
(`Local-first · <b>open source</b>`) simply could not be put into a builder
tree. That is not a preference for string concatenation over the API -- it is
the API being unable to say the thing. A static-site generator with markdown in
it had 16 such interpolations and therefore stayed on template strings.

`unsafeHtml()` is named for what separates it from `text()`, the way Lit's
`unsafeHTML` and React's `dangerouslySetInnerHTML` are: everything handed to it
is parsed as markup, so anything from outside the program is sanitized before it
arrives.

Adding it surfaced a mock/DOM difference underneath. The SSR mock kept
`textContent` and `innerHTML` side by side and let `serialize()` prefer the
text, so `el.textContent = 'a'; el.innerHTML = '<b/>'` rendered `a` under node
and `<b/>` in a browser, and reading `innerHTML` back after setting
`textContent` returned markup that had been replaced. Both now behave as the DOM
does: each replaces the other, last write wins, and the getter reports it.

That difference only shows up when the same template is rendered in both
environments -- which is what a static-site generator under vitest does, and how
it was found.

Reverse-checked, each change against a case that fails without it: escaping in
`unsafeHtml` fails all three of its cases; dropping the setter's clear or the
getter's branch fails the parity cases (the first version of the setter change
had no case that failed without it, and was rewritten rather than kept).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
